### PR TITLE
loading overtone.core causes exception about there not being a `write` method on BufferedWriter [fix attached]

### DIFF
--- a/src/overtone/config.clj
+++ b/src/overtone/config.clj
@@ -1,5 +1,6 @@
 (ns overtone.config
-  (:use [clojure.contrib.io :only (slurp*)])
+  (:use [clojure.contrib.io :only (slurp*)]
+        [clojure.contrib.duck-streams :only (spit)])
   (:import (java.io FileOutputStream FileInputStream)))
 
 ;; Provides a simple key/value configuration system with support for automatically


### PR DESCRIPTION
- fix error of `write` not existing on BufferedWriter by using spit from clojure.contrib.duck-streams instead of clojure.core
