### PR TITLE
Make samples play at normal rate even when sample-rates differ.

### DIFF
--- a/src/overtone/sc/sample.clj
+++ b/src/overtone/sc/sample.clj
@@ -23,12 +23,13 @@
                                  FREE))))))
     
     (defsynth stereo-player
+      "Plays a dual channel audio buffer."
       [buf 0 rate 1.0 start-pos 0.0 loop? 0 vol 1]
       (let [rate (* rate (buf-rate-scale:kr buf))]
-       (out 0
-           (* vol (play-buf 2 buf rate
-                            1 start-pos loop?
-                            FREE)))))))
+        (out 0
+             (* vol (play-buf 2 buf rate
+                              1 start-pos loop?
+                              FREE)))))))
 
 (defonce loaded-samples* (ref {}))
 


### PR DESCRIPTION
Use buf-rate-scale:kr in mono/stereo-player. A buffer with a sample rate of 44.1k will play at normal rate even if the server's sample rate if 48k (for example). The playback rate can still be scaled using the rate param when triggered.
