### PR TITLE
Fix missing import

### DIFF
--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -2,7 +2,8 @@
     ^{:doc "Useful file manipulation fns"
       :author "Sam Aaron"}
   overtone.helpers.file
-  (:import [java.net URL])
+  (:import [java.net URL]
+           [java.io File])
   (:use [clojure.java.io]
         [overtone.helpers.string])
   (:require [org.satta.glob :as satta-glob]


### PR DESCRIPTION
Fixes a missing import in overtone.helpers.file
