### PR TITLE
Sample

### DIFF
--- a/src/overtone/sc/sample.clj
+++ b/src/overtone/sc/sample.clj
@@ -115,7 +115,7 @@
    (sample \"/Users/sam/music/samples/flibble.wav\")
 
   "
-  [path & args]
+  [path]
   (let [s          (load-sample path)
         player     (fn [& pargs]
                      (let [id (:id s)]


### PR DESCRIPTION
Hi guys,

I was running into errors when using long sample paths with `(sample path)`. The samples loaded fine but attempts to play them using the returned function failed due to...

``` clj
(:id (get @loaded-samples* [path args]))
> nil
```

This lookup fails for long file paths like `~/dev/overtone-dev/apps/foo/samples/audio.wav` resulting in the mono-player fn being called with nil instead of the buffers id number.
