### PR TITLE
Improvements to #'buffer-cue. New #'buffer-alloc-read.

### DIFF
--- a/src/overtone/sc/buffer.clj
+++ b/src/overtone/sc/buffer.clj
@@ -46,6 +46,11 @@
          {:type ::buffer}))))
 
 (defn buffer-alloc-read
+  "Synchronously allocates a buffer with the same number of channels as the
+  audio file given by 'path'. Reads the number of samples requested ('n-frames')
+  into the buffer, or fewer if the file is smaller than requested. Reads sound
+  file data from the given starting frame ('start') in the file. If 'n-frames'
+  is less than or equal to zero, the entire file is read."
   ([path]
      (buffer-alloc-read path 0 -1))
   ([path start]


### PR DESCRIPTION
Previously `#'buffer-cue` required the user to provide the number of channels to allocate or it would default to 2. Now it uses `#'buffer-alloc-read` to allocate a buffer with the same number of channels as the file it is reading. It can also now accept a `:start` parameter.

New usage:

``` clj
(def b (buffer-cue "path/to/mono.wav" :start (* 3 44100)))
(buffer-info b)
;=> {:size 65536 :n-channels 1 :rate 44100.0 :id 0}
```
