### PR TITLE
One bar sequencer example fix

### DIFF
--- a/examples/one_bar_sequencer.clj
+++ b/examples/one_bar_sequencer.clj
@@ -25,7 +25,7 @@
     (for [k (keys bar)]
       (let [beat (Math/floor k)
             offset (- k beat)]
-           (if (= 0 (mod (- tick beat) 4))
+           (if (== 0 (mod (- tick beat) 4))
                (let [instruments (bar k)]
                     (dorun
                       (for [instrument instruments]


### PR DESCRIPTION
Equality rule changes between Clojure 1.2 and 1.3 for floating point comparisons. (= vs ==). 
