### PR TITLE
Improve the interaction with an external server not booted by overtone.

### DIFF
--- a/src/overtone/sc/server.clj
+++ b/src/overtone/sc/server.clj
@@ -94,6 +94,7 @@
   ([port] (connect-external-server "127.0.0.1" port))
   ([host port]
      (connect host port)
+     (wait-until-deps-satisfied :server-ready)
      :connected-to-external-server))
 
 (defn boot-external-server


### PR DESCRIPTION
- connect-external-server now waits for the :server-ready dep.
- Connecting jack ports on startup and stopping the server on shutdown
  now only happens if we were the ones who booted the server.

I chose "transient" as the pithy term for a server not booted by overtone; feel free to change that. I'm also new to clojure, so style tweaks are also appreciated (though there's not a lot of code to tweak here).
