### PR TITLE
Notional reworking of dial widget.

### DIFF
--- a/src/overtone/gui/dial.clj
+++ b/src/overtone/gui/dial.clj
@@ -1,12 +1,16 @@
 (ns overtone.gui.dial
-  (:use [seesaw core graphics make-widget])
-  (:require [seesaw.bind :as bind])
-  (:import [javax.swing DefaultBoundedRangeModel]))
+  (:use [seesaw core graphics]
+        [seesaw.behave :only [when-mouse-dragged]]
+        [seesaw.meta :only [put-meta! get-meta]])
+  (:require [seesaw.bind :as bind]))
 
 (def ^{:private true} DIAL_RADIUS 30)
 (def ^{:private true} DIAL_OUTLINE_RADIUS 42)
 (def ^{:private true} DIAL_PADDING 2.5)
 (def ^{:private true} DELTA_DIVISOR -200)
+
+(def ^{:private true} LINE_STYLE (style :foreground "#000000" :stroke 2.0 :cap :round))
+(def ^{:private true} INDICATOR_STYLE (style :foreground "#000000" :background "#000000" :stroke 1.0 :cap :round))
 
 (defn- center-arc
   [x y w h start end]
@@ -14,12 +18,10 @@
 
 (defn- paint-dial-group
   "Paint the dial widget group"
-  [dial-value size c g]
+  [dial-value c g]
   (let [w   (width c)
         h   (height c)
-        s   size
-        line-style (style :foreground "#000000" :stroke 2.0 :cap :round)
-        indicator-style (style :foreground "#000000" :background "#000000" :stroke 1.0 :cap :round)
+        s   (min w h) 
         outline-radius (- s DIAL_PADDING)
         dial-radius (- s (* DIAL_PADDING 6))
         cx (/ w 2)
@@ -29,62 +31,47 @@
         ox (- dx (* DIAL_PADDING 2))
         oy (- dy (* DIAL_PADDING 2))
         theta (- (* @dial-value 270) 135)]
-    (comment
+    
       ; shows the inner circle for debugging and other possible styles
-     (draw g
-       (circle (+ ox 4) (+ oy (- outline-radius 6)) 2) indicator-style)
-     (draw g
-       (circle (+ ox (- outline-radius 6)) (+ oy (- outline-radius 6)) 2) indicator-style)
-     (draw g
-       (center-arc cx cy (/ outline-radius 2) (/ outline-radius 2) -44 269) (style :foreground "#000000" :stroke 2.0 :cap :round))
-      )
-
+     (comment
+       (draw g
+       (circle (+ ox 4) (+ oy (- outline-radius 6)) 2) INDICATOR_STYLE
+       (circle (+ ox (- outline-radius 6)) (+ oy (- outline-radius 6)) 2) INDICATOR_STYLE
+       (center-arc cx cy (/ outline-radius 2) (/ outline-radius 2) -44 269)           (style :foreground "#000000" :stroke 2.0 :cap :round)
+)) 
     (translate g cx cy)
     (rotate g theta)
     (translate g (- 0 cx) (- 0 cy))
-
     (draw g
-          (circle cx cy (/ dial-radius 2)) line-style)
-    (draw g
-          (line cx (+ dy 6) cx (- dy 1)) line-style)
-    ))
+          (circle cx cy (/ dial-radius 2)) LINE_STYLE
+          (line cx (+ dy 6) cx (- dy 1))   LINE_STYLE)))
 
 (defn- dial-widget
   [dial-value size]
-  (let [last-y (atom nil)
-        dial (canvas :id :dial-base
-                     :size [size :by size]
-                     :paint (partial paint-dial-group dial-value size))
-        panel (border-panel
-                :center dial)]
-    (listen dial
-            :mouse-pressed
-            (fn [e] (reset! last-y (.getY e)))
-            :mouse-dragged
-            (fn [e]
+  (let [dial (canvas :preferred-size [size :by size]
+                     :paint (partial paint-dial-group dial-value))]
+    (when-mouse-dragged dial
+      :drag (fn [e [dx dy]]
               (let [cy (.getY e)
-                    delta (double (/ (- cy @last-y) DELTA_DIVISOR))]
+                    delta (double (/ dy DELTA_DIVISOR))]
                 (swap! dial-value
                        (fn [v]
-                         (max 0.0 (min 1.0 (+ v delta)))))
-                (reset! last-y cy)
-                (.repaint (.getSource e)))))
-    panel))
+                         (max 0.0 (min 1.0 (+ v delta))))))))
+    dial))
 
-
-(deftype Dial [panel value model]
-  bind/ToBindable
-  (to-bindable* [this] model)
-  MakeWidget
-  (make-widget* [this] panel))
-
+(defn dial-value 
+  "Returns the atom backing dial d"
+  [d]
+  (get-meta d ::dial-value))
 
 (defn dial
-  [& {:keys [minimum maximum value extent size]
-      :or {minimum 0.0 maximum 100.0 value 50.0 extent 0.0 size 35.0}}]
-  (let [model (DefaultBoundedRangeModel. value extent minimum maximum)
-        dial-value (atom value)
-        panel (dial-widget dial-value size)]
-    (bind/bind dial-value
-               (bind/b-do [v] (.setValue model (+ (* (- maximum minimum) v) minimum))))
-    (Dial. panel dial-value model)))
+  [& {:keys [id class size value] 
+      :or   {size 35.0 value 0.5}}]
+  (let [dial-value (atom value)
+        widget     (dial-widget dial-value size)]
+    (when id    (config! widget :id id))
+    (when class (config! widget :class class))
+    (put-meta! widget ::dial-value dial-value)
+    (bind/bind dial-value (bind/b-do [_] (invoke-soon (repaint! widget))))
+    widget))
+


### PR DESCRIPTION
Based on Jeff's request [here](https://github.com/overtone/overtone/pull/56#issuecomment-3341239), I took a look at the dial widget and reworked it a bit. The implementation is cleaner, but I'm not that satisfied with it. On the plus side, it plays nicely now with selectors, but it still doesn't implement Bindable, Value, or Selection protocols. All programmatic manipulation has to go through the backing atom.

So, this is a bit of a hole in Seesaw. The existing extension mechanisms (`with-widget`, `paintable`, etc) aren't composable and don't adequately support creating truly integrated custom widgets (in Clojure). This is going to take some thought.
