### PR TITLE
Real dial implementation ...

### DIFF
--- a/src/overtone/gui/dial.clj
+++ b/src/overtone/gui/dial.clj
@@ -1,12 +1,20 @@
 (ns overtone.gui.dial
-  (:use [seesaw core graphics make-widget])
-  (:require [seesaw.bind :as bind])
-  (:import [javax.swing DefaultBoundedRangeModel]))
+  (:use [seesaw core graphics]
+        [seesaw.behave :only [when-mouse-dragged]]
+        [seesaw.options :only [apply-options option-map default-option]]
+        [seesaw.keymap :only [map-key]]
+        [seesaw.widget-options :only [WidgetOptionProvider]]
+        [seesaw.value :only [Value]]
+        [seesaw.selection :only [Selection]])
+  (:require [seesaw.bind :as bind]))
 
-(def ^{:private true} DIAL_RADIUS 30)
-(def ^{:private true} DIAL_OUTLINE_RADIUS 42)
 (def ^{:private true} DIAL_PADDING 2.5)
-(def ^{:private true} DELTA_DIVISOR -200)
+
+(def ^{:private true} LINE_STYLE (style :foreground "#000000" :stroke 2.0 :cap :round))
+(def ^{:private true} FOCUS_STYLE (style :foreground "#444444" 
+                                         :stroke (stroke :dashes [4.0])
+                                         :cap :round))
+(def ^{:private true} INDICATOR_STYLE (style :foreground "#000000" :background "#000000" :stroke 1.0 :cap :round))
 
 (defn- center-arc
   [x y w h start end]
@@ -14,12 +22,11 @@
 
 (defn- paint-dial-group
   "Paint the dial widget group"
-  [dial-value size c g]
+  [^javax.swing.DefaultBoundedRangeModel state 
+   ^javax.swing.JPanel c g]
   (let [w   (width c)
         h   (height c)
-        s   size
-        line-style (style :foreground "#000000" :stroke 2.0 :cap :round)
-        indicator-style (style :foreground "#000000" :background "#000000" :stroke 1.0 :cap :round)
+        s   (min w h) 
         outline-radius (- s DIAL_PADDING)
         dial-radius (- s (* DIAL_PADDING 6))
         cx (/ w 2)
@@ -28,61 +35,106 @@
         dy (- cy (/ dial-radius 2))
         ox (- dx (* DIAL_PADDING 2))
         oy (- dy (* DIAL_PADDING 2))
-        theta (- (* @dial-value 270) 135)]
-    (comment
+        theta (- (* (/ (- (.getValue state) 
+                          (.getMinimum state)) 
+                       (- (.getMaximum state)
+                          (.getMinimum state)))
+                    270)
+                 135)]
+    
       ; shows the inner circle for debugging and other possible styles
-     (draw g
-       (circle (+ ox 4) (+ oy (- outline-radius 6)) 2) indicator-style)
-     (draw g
-       (circle (+ ox (- outline-radius 6)) (+ oy (- outline-radius 6)) 2) indicator-style)
-     (draw g
-       (center-arc cx cy (/ outline-radius 2) (/ outline-radius 2) -44 269) (style :foreground "#000000" :stroke 2.0 :cap :round))
-      )
-
+     (comment
+       (draw g
+       (circle (+ ox 4) (+ oy (- outline-radius 6)) 2) INDICATOR_STYLE
+       (circle (+ ox (- outline-radius 6)) (+ oy (- outline-radius 6)) 2) INDICATOR_STYLE
+       (center-arc cx cy (/ outline-radius 2) (/ outline-radius 2) -44 269)           (style :foreground "#000000" :stroke 2.0 :cap :round)
+)) 
+    (if (.isFocusOwner c)
+      (draw g
+            (circle cx cy (+ (/ dial-radius 2) 4)) FOCUS_STYLE))
     (translate g cx cy)
     (rotate g theta)
     (translate g (- 0 cx) (- 0 cy))
-
     (draw g
-          (circle cx cy (/ dial-radius 2)) line-style)
-    (draw g
-          (line cx (+ dy 6) cx (- dy 1)) line-style)))
+          (circle cx cy (/ dial-radius 2)) LINE_STYLE
+          (line cx (+ dy 6) cx (- dy 1))   LINE_STYLE)))
 
-(defn- dial-widget
-  [dial-value size]
-  (let [last-y (atom nil)
-        dial (canvas :id :dial-base
-                     :size [size :by size]
-                     :paint (partial paint-dial-group dial-value size))
-        panel (border-panel
-                :center dial)]
-    (listen dial
-            :mouse-pressed
-            (fn [e] (reset! last-y (.getY e)))
-            :mouse-dragged
-            (fn [e]
-              (let [cy (.getY e)
-                    delta (double (/ (- cy @last-y) DELTA_DIVISOR))]
-                (swap! dial-value
-                       (fn [v]
-                         (max 0.0 (min 1.0 (+ v delta)))))
-                (reset! last-y cy)
-                (.repaint (.getSource e)))))
-    panel))
+(defn dial-proxy [state]
+  (proxy [javax.swing.JPanel clojure.lang.IDeref] []
+    (deref [] state)
+    (paintComponent [g]
+      (proxy-super paintComponent g)
+      (paint-dial-group state this (anti-alias g)))))
 
-(deftype Dial [panel value model]
-  bind/ToBindable
-  (to-bindable* [this] model)
-  MakeWidget
-  (make-widget* [this] panel))
-
+(def ^{:private true} DialClass (class (dial-proxy {})))
 
 (defn dial
-  [& {:keys [minimum maximum value extent size]
-      :or {minimum 0.0 maximum 100.0 value 50.0 extent 0.0 size 35.0}}]
-  (let [model (DefaultBoundedRangeModel. value extent minimum maximum)
-        dial-value (atom value)
-        panel (dial-widget dial-value size)]
-    (bind/bind dial-value
-               (bind/b-do [v] (.setValue model (+ (* (- maximum minimum) v) minimum))))
-    (Dial. panel dial-value model)))
+  [& opts]
+  (let [state  (javax.swing.DefaultBoundedRangeModel.)
+        widget (dial-proxy state)
+        adjust (fn [dv e]
+                 (.setValue state (+ (.getValue state) dv)))
+        percent-adjust (fn [p e]
+                         (adjust (* p (- (.getMaximum state) 
+                                         (.getMinimum state))) e))]
+    (when-mouse-dragged widget 
+      :start (fn [e] (.requestFocusInWindow widget))
+      :drag (fn [e [dx dy]]
+              ; map height of widget to full range of dial, i.e.
+              ; dragging from top to bottom will move dial from
+              ; min to max.
+              (let [range (- (.getMaximum state) (.getMinimum state))
+                    delta (* -1 dy (/ range (height widget)))]
+                (.setValue state (+ (.getValue state) delta)))))
+    (listen widget :focus repaint!)
+
+    ; Repaint when the model changes
+    (bind/bind state
+               (bind/b-do [_] (invoke-soon (repaint! widget))))
+    ; Key bindings
+    (doseq [[k f] [["DOWN" (partial adjust -1)]
+                   ["UP"   (partial adjust 1)]
+                   ["shift DOWN" (partial percent-adjust -0.1)]
+                   ["shift UP" (partial percent-adjust 0.1)]]]
+      (map-key widget k f))
+
+    (apply-options 
+      widget 
+      (concat
+        [:focusable? true]
+        opts))))
+
+(def dial-options
+  (merge
+    default-options
+    (option-map
+      (default-option :value
+        (fn [this v] (.setValue @this v))
+        (fn [this]   (.getValue @this)))
+      (default-option :min
+        (fn [this v] (.setMinimum @this v))
+        (fn [this]   (.getMinimum @this)))
+      (default-option :max
+        (fn [this v] (.setMaximum @this v))
+        (fn [this]   (.getMaximum @this))))))
+
+(extend-type (do DialClass)
+  WidgetOptionProvider
+    (get-widget-option-map* [this] [dial-options])
+    (get-layout-option-map* [this] nil)
+  
+  Value
+    (container?* [this] false)
+    (value* [this] (config this :value))
+    (value!* [this v] (config! this :value v))
+  Selection
+    (get-selection [this] [(value this)])
+    (set-selection [this [v]] (value! this v))
+  
+  bind/ToBindable
+    (to-bindable* [this] @this))
+
+(comment
+  (use 'overtone.gui.dial 'seesaw.core 'seesaw.dev)
+  (def d (dial :id :my-dial))
+  (-> (frame :content d) pack! show!))

--- a/src/overtone/gui/mixer.clj
+++ b/src/overtone/gui/mixer.clj
@@ -17,7 +17,7 @@
   (let [v-slider (slider :value (* @(:volume ins) 100.0) :min 0 :max 100
                     :orientation :vertical)
         vsp (border-panel :center v-slider)
-        p-slider (dial :min -100 :max 100 :value (* @(:pan ins)))
+        p-slider (dial :size [45 :by 45] :min -100 :max 100 :value (* @(:pan ins)))
         mute-state (atom false)
         mute-toggle #(if @mute-state
                        (do


### PR DESCRIPTION
... as custom Seesaw widget with all the bells and whistles (selection, bind, value, etc).

Works on a bounded range model so the API's basically the same as a slider. I also added very basic keyboard support. up/down change the value by +/-1. shift-up/down change the value by 10% in either direction.

This was a great learning experience, stretching Seesaw and forcing me to figure some things out. The solution isn't perfectly beautiful, but it avoids gen-class at least and yields a widget that integrates transparently with the rest of Seesaw. Let me know what you think.

I also tweaked the mixer panel a bit to use it and make sure it was working. I saw another unused dial instance in control.clj. I wasn't sure where you were going with that one, so I left it alone.
