### PR TITLE
Added chord detection to pitch.clj

### DIFF
--- a/examples/chord.clj
+++ b/examples/chord.clj
@@ -1,0 +1,49 @@
+;; Demo of find-chord
+;; find-chord will identify chords from a set of midi notes. To see it in action compile this file.
+;; You will probably need to modify it to read notes from your keyboard.
+;; Change this line :
+;;
+;; (def kb (midi-in "nanoKEY"))
+;;
+;; to match your keyboard type. You can find the necessary changes by typing (midi-in) in the repl.
+;; You can see the output by monitoring the logfile using this command:
+;;
+;; tail -f  ~/.overtone/log/log.log
+
+
+(ns pitch.chord
+  (:use [overtone.live]
+        [overtone.util.log]))
+
+(definst beep [note 60]
+  (let [src (sin-osc (midicps note))
+        env (env-gen (perc 0.1 0.2) :action FREE)]
+    (* src env)))
+
+(beep 86)
+
+(def current-notes (ref #{}))
+
+(defn add-to-current-notes
+  [new-note]
+  (dosync (ref-set current-notes (set (cons new-note @current-notes)))))
+
+(defn remove-from-current-notes
+  [old-note]
+  (dosync (ref-set current-notes (set (disj @current-notes old-note)))))
+
+(def kb (midi-in "nanoKEY"))
+
+(defn midi-player [event ts]
+  (do (info event)
+      (cond
+       (= :note-on (:cmd event))
+       (do (beep (:note event))
+           (add-to-current-notes (:note event)))
+       (= :note-off (:cmd event))
+       (remove-from-current-notes (:note event)))
+      (info "chord "
+            (find-chord @current-notes))))
+
+(midi-handle-events kb #'midi-player)
+

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -352,6 +352,7 @@
   "Returns a list of notes for the specified scale. The root must be in
    midi note format i.e. :C4 or :Bb4
 
+
    (scale :c4 :major)  ; c major      -> (60 62 64 65 67 69 71 72)
    (scale :Bb4 :minor) ; b flat minor -> (70 72 73 75 77 78 80 82)"
 
@@ -536,6 +537,81 @@
      (case tuning
            :equal-tempered (nth-equal-tempered-freq base-freq (nth-interval n mode)))))
 
+(defn find-name
+  "Returnd the name of the first matching thing found in things
+  or nil if not found"
+  ([thing things]
+     (if (= (val (first things)) thing)
+       (key (first things))
+       (if (< 1 (count things))
+         (find-name thing (rest things))))))
+
+(defn find-scale-name
+  "Return the name of the first matching scale found in SCALE
+  or nil if not found
+
+  ie: (find-scale-name [2 1 2 2 2 2 1]
+  :melodic-minor-asc"
+  [scale]
+  (find-name scale SCALE))
+
+(defn find-note-name
+  [note]
+  (REVERSE-NOTES (mod note 12)))
+
+(defn- fold-note
+  "Folds note intervals into a 2 octave range so that chords using notes
+  spread across multiple octaves can be correctly recognised."
+  [note]
+  (if (or (< 21 note) (contains? #{20 19 16 12} note))
+    (fold-note (- note 12))
+     note ))
+
+(defn- simplify-chord
+  "expects notes to contain 0 (the root note) Reduces all notes into 2 octaves. This will allow
+  identification of fancy jazz chords, but will miss some simple chords if they are spread over
+  more than 1 octave."
+  [notes]
+  (set (map (fn [x] (fold-note x)) notes)))
+
+(defn- compress-chord
+  "expects notes to contain 0 (the root note) Reduces all notes into 1 octave. This will lose
+  all the fancy jazz chords but recognise sparse multiple octave smple chords"
+  [notes]
+  (set (map (fn [x] (mod x 12)) notes)))
+
+(defn- select-root
+  "Adds a new root note below the lowest note present in notes"
+  [notes root-index]
+  (if (< 0 root-index)
+    (let [new-root (nth (seq (sort notes)) root-index)
+         lowest-note (first (sort notes))
+         octaves (+ 1 (quot (- new-root lowest-note) 12))]
+      (set (cons (- new-root (* octaves 12)) notes)))
+    notes))
+
+(defn- find-chord-with-low-root
+  "Finds the chord represented by notes
+   Assumes the root note is the lowest note in notes
+   notes can be spread over multiple octaves"
+  [notes]
+  (if (< 0 (count notes))
+    (let [root (first (sort notes))
+          adjusted-notes (set (map (fn [x] (- x root)) notes ))]
+      (or (find-name (simplify-chord adjusted-notes) CHORD)
+          (find-name (compress-chord adjusted-notes) CHORD)))))
+
+(defn find-chord
+  [notes]
+  (loop [note 0]
+    (if (< note (count notes) )
+      (let [mod-notes (select-root notes note)
+            chord  (find-chord-with-low-root mod-notes)
+            root (find-note-name (first (sort mod-notes)))]
+       (if chord
+         {:root root :chord-type chord}
+         (recur (inc note))))
+      nil)))
 
 ;; * shufflers (randomize a sequence, or notes within a scale, etc.)
 ;; *


### PR DESCRIPTION
Chord detection added to pitch.clj, and examples/chord.clj to demonstrate its use. This is a context free chord analyser designed to give information to musicians wishing to join in a jam session.
