### PR TITLE
Fixed metronome bug that caused it to glitch when changing bpm

### DIFF
--- a/src/overtone/music/rhythm.clj
+++ b/src/overtone/music/rhythm.clj
@@ -49,7 +49,7 @@
   (bpm   [this new-bpm]
     (let [cur-beat (beat this)
           new-tick (beat-ms 1 new-bpm)
-          new-start (- (now) (* new-tick cur-beat))]
+          new-start (- (beat this cur-beat) (* new-tick cur-beat))]
       (reset! start new-start)
       (reset! bpm new-bpm))
     [:bpm new-bpm])


### PR DESCRIPTION
metronome was restarting at the current moment as defined by (now) rather than waiting till the next beat. This meant that there would be a glitch on every bpm change of somewhere between 0 and 1 beat. 

This can be demonstrated by running a loop using a slow metronome and changing the bpm. The following code resets the bpm to the value of riff-bpm before scheduling the notes in riff to be played. This code is for demonstration purposes only. Redefine riff-bpm to change the bpm.

``` clojure


(def metro (metronome 12))

(def riff [:i :ii :iii :iv :v :vi :vii :i+])

(def offsets [0 1/8 2/8 3/8 4/8 5/8 6/8 7/8])

(def riff-bpm 10)

(def riff-scale :minor)

(def riff-root :c5)

(defn play-riff
  [metro beat]
  (bpm metro riff-bpm)
  (let [notes-to-play (degrees->pitches riff riff-scale riff-root)
        next-bar (metro (inc beat))]

      (dorun
       (map (fn [note offset]
              (at (metro (+ beat offset))
                  (beep note)
                  (info "RiffPlayer note: " note
                          "  time: " (metro (+ beat offset))
                          "  beat: " beat
                          "  offset: "offset)))
            notes-to-play
            offsets))
      (info "BPM: " (bpm metro) "     Next bar time: " next-bar)
      (apply-at next-bar  #'play-riff [metro (inc beat)])))
```
