### PR TITLE
Get SearchResults to check inputs properly in IPersistentCollection#equiv

### DIFF
--- a/src/overtone/libs/freesound/search_results.clj
+++ b/src/overtone/libs/freesound/search_results.clj
@@ -17,7 +17,8 @@
   (empty [_]
     (.empty results-seq))
   (equiv [this that]
-    (and (= (.count this)
+    (and (coll? that)
+         (= (.count this)
             (.count that))
          (.equiv results-seq (.results that))))
 


### PR DESCRIPTION
An instance of SearchResults doesn't print nicely in the repl:

```
REPL started; server listening on localhost port 25592
user=> (use 'overtone.libs.freesound)
nil
user=> (def res (freesound-search "kick drum"))
#'user/res
user=> res
overtone.libs.freesound.search_results.SearchResults@58bd3b2d
IllegalArgumentException No matching field found: count for class java.lang.Object clojure.lang.Reflector.getInstanceField (Reflector.java:289)
user=> 
```

The problem is that overtone.libs.freesound.search_results.SearchResults#equiv calls .count on its argument before determining that the argument actually has a count method. This commit adds a quick check to coll? first.
