### PR TITLE
Set external scsynth.exe working directory on Windows.

### DIFF
--- a/src/overtone/helpers/lib.clj
+++ b/src/overtone/helpers/lib.clj
@@ -3,7 +3,8 @@
       :author "Jeff Rose and Sam Aaron"}
   overtone.helpers.lib
   (:import [java.util ArrayList Collections]
-           [java.util.concurrent TimeUnit TimeoutException])
+           [java.util.concurrent TimeUnit TimeoutException]
+           [java.io File])
   (:use [clojure.stacktrace]
         [clojure.pprint]
         [overtone.helpers doc]))
@@ -330,7 +331,9 @@
   "Returns a string representing the path for SuperCollider on Windows"[]
   (let [p-files-dir (System/getenv "PROGRAMFILES(X86)")
         p-files-dir (or p-files-dir (System/getenv "PROGRAMFILES"))
-        p-files     (ls p-files-dir)
-        sc-files    (grep p-files "SuperCollider")
-        recent-sc   (last (sort (seq sc-files)))]
-    (str p-files-dir "\\" recent-sc "\\scsynth.exe")))
+        p-files-dir (File. p-files-dir)
+        p-files     (map str (.listFiles p-files-dir))
+        sc-files    (filter #(.contains % "SuperCollider") p-files)
+        recent-sc   (last (sort (seq sc-files)))
+        ]
+      recent-sc))

--- a/src/overtone/sc/defaults.clj
+++ b/src/overtone/sc/defaults.clj
@@ -1,7 +1,6 @@
 (ns overtone.sc.defaults
   (:use [overtone.helpers.file :only [dir-exists?]]
-        [overtone.helpers.lib :only [windows-sc-path]]
-        [overtone.repl.shell :only [ls grep]])
+        [overtone.helpers.lib :only [windows-sc-path]])
   (:require [overtone.at-at :as at-at]))
 
 (def DEFAULT-MASTER-VOLUME
@@ -49,7 +48,7 @@
   "Default system paths to an externally installed SuperCollider server for
   various operating systems."
   {:linux ["scsynth"]
-   :windows [(windows-sc-path)]
+   :windows [(str (windows-sc-path) "\\scsynth.exe")]
    :mac  ["/Applications/SuperCollider/scsynth"
           "/Applications/SuperCollider.app/Contents/Resources/scsynth"
           "/Applications/SuperCollider/SuperCollider.app/Contents/Resources/scsynth"]})


### PR DESCRIPTION
This removes the need for :ugens-paths in the config file by default.
