### PR TITLE
Added bar to metronome

### DIFF
--- a/src/overtone/music/rhythm.clj
+++ b/src/overtone/music/rhythm.clj
@@ -11,11 +11,19 @@
       (metro-start [metro] [metro start-beat]
         "Returns the start time of the metronome. Also restarts the metronome at
      'start-beat' if given.")
+      (metro-bar-start [metro] [metro start-bar])
       (metro-tick [metro]
         "Returns the duration of one metronome 'tick' in milleseconds.")
+      (metro-tock [metro]
+    "Returns the duration of one bar in milliseconds.")
       (metro-beat [metro] [metro beat]
         "Returns the next beat number or the timestamp (in milliseconds) of the
      given beat.")
+      (metro-bar [metro] [metro  bar]
+    "Returns the next bar number or the timestamp (in milliseconds) of the
+     given bar")
+      (metro-bpb [metro] [metro new-bpb]
+    "Get the current beats per bar or change it to new-bpb")
       (metro-bpm [metro] [metro new-bpm]
         "Get the current bpm or change the bpm to 'new-bpm'."))))
 
@@ -37,7 +45,7 @@
 ;  ([] (bar 1))
 ;  ([b] (* (bar 1) (first @*signature) b)))
 
-(deftype Metronome [start bpm]
+(deftype Metronome [start bar-start bpm bpb]
 
   IMetronome
   (metro-start [metro] @start)
@@ -45,17 +53,36 @@
     (let [new-start (- (now) (* start-beat (metro-tick metro)))]
       (reset! start new-start)
       new-start))
+  (metro-bar-start [metro] @bar-start)
+  (metro-bar-start [metro start-bar]
+    (let [new-bar-start (- (now) (* start-bar (metro-tock metro)))]
+      (reset! bar-start new-bar-start)
+      new-bar-start))
   (metro-tick  [metro] (beat-ms 1 @bpm))
+  (metro-tock  [metro] (beat-ms @bpb @bpm))
   (metro-beat  [metro] (inc (long (/ (- (now) @start) (metro-tick metro)))))
   (metro-beat  [metro b] (+ (* b (metro-tick metro)) @start))
+  (metro-bar   [metro] (inc (long (/ (- (now) @bar-start) (metro-tock metro)))))
+  (metro-bar   [metro b] (+ (* b (metro-tock metro)) @bar-start))
   (metro-bpm   [metro] @bpm)
   (metro-bpm   [metro new-bpm]
-    (let [cur-beat (metro-beat metro)
-          new-tick (beat-ms 1 new-bpm)
-          new-start (- (metro-beat metro cur-beat) (* new-tick cur-beat))]
+    (let [cur-beat      (metro-beat metro)
+          cur-bar       (metro-bar metro)
+          new-tick      (beat-ms 1 new-bpm)
+          new-tock      (* @bpb new-tick)
+          new-start     (- (metro-beat metro cur-beat) (* new-tick cur-beat))
+          new-bar-start (- (metro-bar metro cur-bar) (* new-tock cur-bar))]
       (reset! start new-start)
+      (reset! bar-start new-bar-start)
       (reset! bpm new-bpm))
     [:bpm new-bpm])
+  (metro-bpb   [metro] @bpb)
+  (metro-bpb   [metro new-bpb]
+    (let [cur-bar       (metro-bar metro)
+          new-tock      (beat-ms new-bpb @bpm)
+          new-bar-start (- (metro-bar metro cur-bar) (* new-tock cur-bar))]
+      (reset! bar-start new-bar-start)
+      (reset! bpb new-bpb)))
 
   clojure.lang.ILookup
   (valAt [this key] (.valAt this key nil))
@@ -79,6 +106,10 @@
   with no arguments to get the next beat number, or pass it a beat number
   to get the timestamp to play a note at that beat.
 
+  Metronome also works with bars. Set the number of beats per bar using
+  metro-bpb (defaults to 4). metro-bar returns a timestamp that can be used
+  to play a note relative to a specified bar.
+
   (def m (metronome 128))
   (m)          ; => <next beat number>
   (m 200)      ; => <timestamp of beat 200>
@@ -86,8 +117,10 @@
   (m :bpm 140) ; => set bpm to 140"
   [bpm]
   (let [start (atom (now))
-        bpm   (atom bpm)]
-    (Metronome. start bpm)))
+        bar-start (atom @start)
+        bpm   (atom bpm)
+        bpb   (atom 4)]
+    (Metronome. start bar-start bpm bpb)))
 
 ;== Grooves
 ;


### PR DESCRIPTION
Osc events can be scheduled to happen at the beginning of the next bar using (metro-bar metro) in exactly the same way that we use (metro-beat metro)
The beats per bar can be set using (metro-bpb metro n) 
Changing bpb and bpm on the fly works, but with some small timing issues when changing bpm (only noticeable if the change is large) due to the limitations of the at function. So far I have not found a way to ensure that bpm changes can be forced to happen only at the start of a bar, so whereas the calculated bar length changes directly from the old value to the new, there may be a bar consisting of some beats at the old bpm and some at the new bpm depending on when the change happens. This causes a slight pause before the first beat of a new bar if the bpm is adjusted downwards. Conversely the first beat of a new bar when changing the bpm up may happen a little to soon. This should present no problems in most cases, but needs to be considered if you want to play with radical timing changes.
As far as I can tell there is no effect whatsoever if metronome is used as before.
