### PR TITLE
potential fix (or at least starting point) for Issue 111

### DIFF
--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -15,8 +15,8 @@
 (defn get-current-directory []
   (. (java.io.File. ".") getCanonicalPath))
 
-(defn print-if-verbose
-  "Prints the arguments if *verbose-overtone-file-helpers* is bound to true. If
+(defn println-if-verbose
+  "Printlns the arguments if *verbose-overtone-file-helpers* is bound to true. If
   it is also bound to an integer, will print a corresponding number of spaces at
   the start of each line to indent the output."
   [& to-print]
@@ -24,6 +24,13 @@
     (when (integer? *verbose-overtone-file-helpers*)
       (dotimes [_ *verbose-overtone-file-helpers*] (print " ")))
     (apply println to-print)))
+
+(defn print-if-verbose
+  "Prints the arguments if *verbose-overtone-file-helpers* is bound to true."
+  [& to-print]
+  (when *verbose-overtone-file-helpers*
+    (apply print to-print)
+    (flush)))
 
 (defn pretty-file-size
   "Takes number of bytes and returns a prettied string with an appropriate unit:
@@ -204,7 +211,8 @@
                                         (< (:val slice) max))
                                slice))
                            slices)]
-      (print-if-verbose (str (:perc slice) "% (" (pretty-file-size num-copied-bytes)  ") completed")))))
+      ;;(println-if-verbose (str (:perc slice) "% (" (pretty-file-size num-copied-bytes)  ") completed"))
+      (print-if-verbose "="))))
 
 (defn- remote-file-copy [in-stream out-stream file-size]
   "Similar to  the corresponding implementation of #'do-copy in 'clojure.java.io
@@ -212,14 +220,18 @@
   statements when *verbose-overtone-file-helpers* is bound to true."
   (let [buf-size 2048
         buffer   (make-array Byte/TYPE buf-size)
-        slices   (percentage-slices file-size 100)]
+        slices   (percentage-slices file-size 50)]
+    (if (> file-size buf-size)
+        (print-if-verbose "      ["))
     (loop [bytes-copied 0]
       (let [size (.read in-stream buffer)]
         (print-file-copy-status bytes-copied size file-size slices)
         (when (pos? size)
           (do (.write out-stream buffer 0 size)
               (recur (+ size bytes-copied))))))
-    (print-if-verbose "--> Download successful")))
+    (if (> file-size buf-size)
+      (print-if-verbose "]\n"))
+    (println-if-verbose "--> Download successful")))
 
 (defn- download-file-without-timeout
   "Downloads remote file at url to local file specified by target path. Has
@@ -393,7 +405,7 @@
          (catch Exception e
            (rm-rf! path)
            (Thread/sleep wait-t)
-           (print-if-verbose (str "Download timed out. Retry " (inc attempts-made) ": " url ))
+           (println-if-verbose (str "Download timed out. Retry " (inc attempts-made) ": " url ))
            (download-file* url path timeout n-retries wait-t (inc attempts-made)))))))
 
 (defn- print-download-file
@@ -401,7 +413,7 @@
   (let [size     (remote-file-size url)
         p-size   (pretty-file-size size)
         size-str (if (<= size 0) "" (str "(" p-size ")"))]
-    (print-if-verbose (str "--> Downloading file " size-str " - "  url))))
+    (println-if-verbose (str "--> Downloading file " size-str " - "  url))))
 
 (defn download-file
   "Downloads the file pointed to by url to local path. If no timeout


### PR DESCRIPTION
I've modified the code in src/overtone/helpers/file.clj to be a bit less verbose.  Let me know if you think this is a reasonable change to resolve Issue 111.

It changes the output from this:

```
 user> (freesound-path 704)
 --> Asset not cached - starting download...
   --> Downloading file  - http://www.freesound.org/api/sounds/704?api_key=47efd585321048819a2328721507ee23
   --> Download successful
 --> Asset not cached - starting download...
   --> Downloading file (9 KB) - http://www.freesound.org/api/sounds/704/serve?api_key=47efd585321048819a2328721507ee23
   1% (0 B) completed
   15% (1 KB) completed
   29% (2 KB) completed
   50% (4 KB) completed
   72% (6 KB) completed
   93% (8 KB) completed
   --> Download successful
 "/Users/rallen/.overtone/assets/www.freesound.org-api-sounds-704-serveapi_key47efd585321048819a2328721507ee23---1237048159/bwoop2.wav--744037877"
```

To this:

```
 user> (freesound-path 704)
 --> Asset not cached - starting download...
   --> Downloading file  - http://www.freesound.org/api/sounds/704?api_key=47efd585321048819a2328721507ee23
   --> Download successful
 --> Asset not cached - starting download...
   --> Downloading file (9 KB) - http://www.freesound.org/api/sounds/704/serve?api_key=47efd585321048819a2328721507ee23
       [======]
   --> Download successful
 "/Users/rallen/.overtone/assets/www.freesound.org-api-sounds-704-serveapi_key47efd585321048819a2328721507ee23---1237048159/bwoop2.wav--744037877"
```

For a file that is a bit more reasonable in size, instead of 100 lines of status, I changed the limit to be 50 chars, so it looks like this:

```
 user> (freesound-path 28138)
 --> Asset not cached - starting download...
   --> Downloading file  - http://www.freesound.org/api/sounds/28138?api_key=47efd585321048819a2328721507ee23
   --> Download successful
 --> Asset not cached - starting download...
   --> Downloading file (4 MB) - http://www.freesound.org/api/sounds/28138/serve?api_key=47efd585321048819a2328721507ee23
       [=================================================]
   --> Download successful
 "/Users/rallen/.overtone/assets/www.freesound.org-api-sounds-28138-serveapi_key47efd585321048819a2328721507ee23--508896364/Valladolidstation2_kort.wav--191421259"
```

In the code, I chose to modify the routine print-if-verbose to be println-if-verbose since that was closer to waht it was actually doing.  I added new version called print-if-verbose for the new functionality.  I didn't see the println-if-verbose used outside this file.

[This is my first pull request, so let me know if I'm doing this right]
