### PR TITLE
Fixed lein deps errors that break offline operation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -55,6 +55,6 @@
                  [overtone/scsynth-extras "3.5.2-SNAPSHOT"]
                  [clj-glob "1.0.0"]
                  [org.clojure/core.match "0.2.0-alpha9"]
-                 [seesaw "1.4.1"]]
+                 [seesaw "1.4.2"]]
   :native-path "native"
   :jvm-opts ~(jvm-opts))


### PR DESCRIPTION
Upgraded Seesaw to 1.4.2 to avoid lein deps errors that prevent Overtone working offline.

I haven't used the Seesaw integration, so this needs to be tested by someone who does, but it does fix the issue of Overtone not working with no connectivity.
