### PR TITLE
Fixed at_all example

### DIFF
--- a/src/overtone/examples/compositions/at_all.clj
+++ b/src/overtone/examples/compositions/at_all.clj
@@ -3,28 +3,25 @@
     overtone.live
     [overtone.inst.sampled-piano :only [sampled-piano]]))
 
-(defn at-bpm [beats-per-minute]
-  (let [start (now)
-        ms-per-minute (* 60 1000)
-        ms-per-beat (/ ms-per-minute beats-per-minute)]
-    #(+ start (* ms-per-beat %))))
-
-(defn from [timing offset]
-  #(timing (+ offset %)))
+(defn from [metro offset]
+  (fn [beat] (metro (+ beat offset))))
 
 (defn speed-up [metro factor]
   (fn [beat] (metro (/ beat factor))))
 
 (def base 60)
-(defn ground [note] (+ base note))
 
-(def note# (comp sampled-piano ground))
-(defn chord# [chord] (doseq [note (vals chord)] (note# note)))
+(defn play-note [relative-midi]
+  (-> relative-midi (+ base) sampled-piano))
 
-(def ionian #(let [interval (mod % 7)
-                  note ([0 2 4 5 7 9 11] interval)
-                  octave (quot (- % interval) 7)]
-               (+ (* 12 octave) note)))
+(defn play-chord [chord]
+  (doseq [note (vals chord)] (play-note note)))
+
+(defn ionian [degree]
+  (let [interval (mod degree 7)
+        note ([0 2 4 5 7 9 11] interval)
+        octave (quot (- degree interval) 7)]
+    (+ (* 12 octave) note)))
 
 (defn triad [scale root]
   (zipmap [:i :iii :v]
@@ -45,65 +42,65 @@
 
 (def progression [I I II II II V I (update-in V [:base] lower)])
 
-(defn rhythm-n-bass# [timing [chord1 chord2 & chords]]
+(defn rhythm-n-bass [timing [chord1 chord2 & chords]]
   (do
-    (at (timing 0) (note# (:base chord1)))
-    (at (timing 2) (chord# (dissoc chord1 :base)))
-    (at (timing 3) (note# (:base chord1)))
-    (at (timing 4) (note# (:base chord2)))
-    (at (timing 6) (chord# (dissoc chord2 :base)))
+    (at (timing 0) (play-note (:base chord1)))
+    (at (timing 2) (play-chord (dissoc chord1 :base)))
+    (at (timing 3) (play-note (:base chord1)))
+    (at (timing 4) (play-note (:base chord2)))
+    (at (timing 6) (play-chord (dissoc chord2 :base)))
     (let [next (from timing 8)]
       (if chords
-        (rhythm-n-bass# next chords)
+        (rhythm-n-bass next chords)
         next))))
 
-(defn even-melody# [timing [note & notes]]
+(defn even-melody [timing [note & notes]]
   (do
-    (at (timing 0) (note# note))
+    (at (timing 0) (play-note note))
     (let [next (from timing 1)]
       (if notes
-        (even-melody# next notes)
+        (even-melody next notes)
         next))))
 
-(defn intro# [timing]
-    (even-melody# timing (take 32 (cycle (map ionian [5 4]))))
-    (rhythm-n-bass# timing (take 8 (cycle progression))))
+(defn intro [timing]
+    (even-melody timing (take 32 (cycle (map ionian [5 4]))))
+    (rhythm-n-bass timing (take 8 (cycle progression))))
 
-(defn first-bit# [timing]
+(defn first-bit [timing]
   (-> timing
     (from -1)
     (speed-up 2)
-    (even-melody# (map ionian [2 4 5 4 4 2 4]))
+    (even-melody (map ionian [2 4 5 4 4 2 4]))
     (from 9)
-    (even-melody# (map ionian [-2 1 2 1 1 -2 1]))
+    (even-melody (map ionian [-2 1 2 1 1 -2 1]))
     (from 9)
-    (even-melody# (map ionian [-2 1 2 1 1 -2 1 2 3 4]))
+    (even-melody (map ionian [-2 1 2 1 1 -2 1 2 3 4]))
     (from 6)
-    (even-melody# (map ionian [-1 -2 -3 0 0 -3 0 1 0 -3])))
-  (rhythm-n-bass# timing (take 8 (cycle progression))))
+    (even-melody (map ionian [-1 -2 -3 0 0 -3 0 1 0 -3])))
+  (rhythm-n-bass timing (take 8 (cycle progression))))
 
-(defn variation# [timing]
+(defn variation [timing]
   (-> timing
     (speed-up 2)
     (from 9)
-    (even-melody# (map ionian [11 11 12 9 7]))
+    (even-melody (map ionian [11 11 12 9 7]))
     (from 11)
-    (even-melody# (map ionian [8 8 9 8 3]))
+    (even-melody (map ionian [8 8 9 8 3]))
     (from 11)
-    (even-melody# (map ionian [8 8 9 6 4]))
+    (even-melody (map ionian [8 8 9 6 4]))
     (from 11)
-    (even-melody# (map ionian [11 11 12 11 8])))
-  (first-bit# timing))
+    (even-melody (map ionian [11 11 12 11 8])))
+  (first-bit timing))
 
-(defn final-chord# [timing]
+(defn final-chord [timing]
   (-> timing
     (from -1)
     (speed-up 2)
-    (even-melody# (map ionian [11 13 14])))
+    (even-melody (map ionian [11 13 14])))
   (at (timing 0)
-      (chord# (update-in I [:i] raise))))
+      (play-chord (update-in I [:i] raise))))
 
-(defn play# [] (-> (metronome 160) (from 2) intro# first-bit#
-                 (speed-up 3/2) variation# final-chord#))
+(defn play [] (-> (metronome 160) (from 2) intro first-bit
+                 (speed-up 3/2) variation final-chord))
 
-(play#)
+(play)


### PR DESCRIPTION
Issue #150 was that the piece was originally written to use a pure timing function, not a metronome specifically.

The melody is played at twice the speed of the bass and chords, which is achieved by wrapping the timing function. If `metronome-bpm` is used there are two problems:
- There's a crash because the timing function isn't always a metronome (due to wrapping/composition)
- The speedup doesn't work as intended because the global stateful timing can't cope with the melody and chords being on different speeds

I resolved the issue by using simple function composition for the speedup function again.
