### PR TITLE
Undo renaming of connection-info to server-info

### DIFF
--- a/src/overtone/gui/scope.clj
+++ b/src/overtone/gui/scope.clj
@@ -43,7 +43,7 @@
   (when (server-disconnected?)
     (throw (Exception. "Cannot use scopes until a server has been booted or connected")))
   (when (external-server?)
-    (throw (Exception. (str "Sorry, it's  only possible to use scopes with an internal server. Your server connection info is as follows: " (server-info))))))
+    (throw (Exception. (str "Sorry, it's  only possible to use scopes with an internal server. Your server connection info is as follows: " (connection-info))))))
 
 (defn- update-scope-data
   "Updates the scope by reading the current status of the buffer and repainting.

--- a/src/overtone/sc/server.clj
+++ b/src/overtone/sc/server.clj
@@ -12,7 +12,7 @@
         [overtone.osc :only [in-osc-bundle without-osc-bundle]])
   (:require [overtone.config.log :as log]))
 
-(defn server-info
+(defn connection-info
   "Returns connection information regarding the currently connected
   server"
   []
@@ -36,12 +36,12 @@
 (defn internal-server?
   "Returns true if the server is internal"
   []
-  (= :internal (:connection-type (server-info))))
+  (= :internal (:connection-type (connection-info))))
 
 (defn external-server?
   "Returns true if the server is external"
   []
-  (= :external (:connection-type (server-info))))
+  (= :external (:connection-type (connection-info))))
 
 (defmacro at
   "All messages sent within the body will be sent in the same


### PR DESCRIPTION
Fixes the naming clash that was caused by the original #176 fix.
