### PR TITLE
Add simple :pan control to the sample players.  

### DIFF
--- a/src/overtone/sc/sample.clj
+++ b/src/overtone/sc/sample.clj
@@ -17,35 +17,37 @@
   (do
     (defsynth mono-player
       "Plays a single channel audio buffer."
-      [buf 0 rate 1.0 start-pos 0.0 loop? 0 vol 1 out-bus 0]
+      [buf 0 rate 1.0 start-pos 0.0 loop? 0 vol 1 pan 0 out-bus 0]
       (out out-bus (* vol
                       (pan2
                        (scaled-play-buf 1 buf rate
                                         1 start-pos loop?
-                                        FREE)))))
+                                        FREE)
+                       pan))))
 
     (defsynth stereo-player
       "Plays a dual channel audio buffer."
-      [buf 0 rate 1.0 start-pos 0.0 loop? 0 vol 1 out-bus 0]
-      (out out-bus (* vol
-                      (scaled-play-buf 2 buf rate
-                                       1 start-pos loop?
-                                       FREE))))
+      [buf 0 rate 1.0 start-pos 0.0 loop? 0 vol 1 pan 0 out-bus 0]
+      (let [s (scaled-play-buf 2 buf rate
+                               1 start-pos loop?
+                               FREE)]
+            (out out-bus (* vol (balance2 (first s) (second s) pan)))))
 
     (defsynth mono-stream-player
       "Plays a single channel streaming buffer-cue. Must be freed manually when
       done."
-      [buf 0 rate 1 loop? 0 vol 1 out-bus 0]
+      [buf 0 rate 1 loop? 0 vol 1 pan 0 out-bus 0]
       (out out-bus (* vol
                       (pan2
-                       (scaled-v-disk-in 1 buf rate loop?)))))
+                       (scaled-v-disk-in 1 buf rate loop?)
+                       pan))))
 
     (defsynth stereo-stream-player
       "Plays a dual channel streaming buffer-cue. Must be freed manually when
       done."
-      [buf 0 rate 1 loop? 0 vol 1 out-bus 0]
-      (out out-bus (* vol
-                      (scaled-v-disk-in 2 buf rate loop?))))))
+      [buf 0 rate 1 loop? 0 vol 1 pan 0 out-bus 0]
+      (let [s (scaled-v-disk-in 2 buf rate loop?)]
+        (out out-bus (* vol (balance2 (first s) (second s) pan)))))))
 
 (defonce loaded-samples* (atom {}))
 (defonce cached-samples* (atom {}))


### PR DESCRIPTION
I wanted to pan some samples and found I couldn't.  So, I thought I'd try a pull request to add the feature.

Example usage:

;; mono sample
(def kick (sample (freesound-path 2086)))
(kick :pan -1)

and

;; stereo sample
(def sol-do (sample (freesound-path 44929)))
(sol-do :pan 0.5)
