### PR TITLE
Adding Coyote onset detector ugen to exceptions which can take ar ugens

### DIFF
--- a/src/overtone/sc/machinery/ugen/specs.clj
+++ b/src/overtone/sc/machinery/ugen/specs.clj
@@ -183,6 +183,9 @@
                  ;; Special case Amplitude ugen which may have ar ugens plugged into it
                  (and (= "Amplitude" (:name ugen))
                       (= :ar (:rate-name bad-input)))
+                 ;; Special case Coyote ugen which may have ar ugens plugged into it
+                 (and (= "Coyote" (:name ugen))
+                      (= :ar (:rate-name bad-input)))
                  ;; Special case Pitch ugen which may have ar ugens plugged into it
                  (and (= "Pitch" (:name ugen))
                       (= :ar (:rate-name bad-input)))


### PR DESCRIPTION
Tested, detecting away happily:

```
(definst onsetdetector [bus 0]
    (send-trig (> (coyote (sound-in bus)) 0.0) 123 123.123))
```
