### PR TITLE
Adding a helper for getting the beat sent.

### DIFF
--- a/src/overtone/synth/timing.clj
+++ b/src/overtone/synth/timing.clj
@@ -3,7 +3,10 @@
             beats."
       :author "Sam Aaron"}
   overtone.synth.timing
-  (:use [overtone.core]))
+  (:use [overtone.core]
+        [overtone.helpers.lib :only [uuid]]))
+
+(defonce count-trig-id (trig-id))
 
 (defsynth trigger [rate 100 out-bus 0]
   (out:kr out-bus (impulse:kr rate)))
@@ -13,3 +16,6 @@
 
 (defsynth divider [div 32 in-bus 0 out-bus 0]
   (out:kr out-bus (pulse-divider (in:kr in-bus) div)))
+
+(defsynth send-beat [in-bus 0 beat-bus 0 id count-trig-id]
+  (send-trig (in:kr in-bus) id (+ (in:kr beat-bus) 1)))


### PR DESCRIPTION
Would something like this be helpful?

Usage:

``` clojure
(send-beat :in-bus beat-trg-bus :beat-bus beat-cnt-bus :id count-trig-id)
```

I've been playing with beat timing and signals and _guessed_ a helper like this might live here?
Since these helpers are all about beats?

I'm finding it very useful to have some global beat event that I can hook devices into.

I could be doing something silly and too bespoke so please excuse my over enthusiasm.
