### PR TITLE
quick-start commands updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ collaborating with music.  It provides:
     # Install lein2
     # https://github.com/technomancy/leiningen
 
-    $ lein new insane-noises
+    $ lein new insane-noise
+    $ cd insane-noise
 
-    # add the following dependencies to insane-noises/project.clj
-    # [org.clojure/clojure "1.5.1"]
+    # add the following dependecy to insane-noises/project.clj]
     # [overtone "0.9.1"]
 
-    $ cd insane-noises
+    $ lein deps
     $ lein repl
 ```
 


### PR DESCRIPTION
The quick-start isn't so quick. If you didn't know you had to run a `lein deps` you would be getting an error when you call `(use 'overtone.live)`. Also, you get `[org.clojure/clojure "1.5.1"]` as default with any lein project. 

EDIT --> You can't really get a 'quick-start' without doing the detailed install instructions. Maybe that should be highlighted to avoid the horrendous stack traces that await all those who think a 'lein deps' is gonna get them out of trouble...
