### PR TITLE
Clearer errors about invalid file types.

### DIFF
--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -9,11 +9,9 @@
   (:require [clojure.data.json :as json]
             [overtone.libs.asset :as asset]
             [overtone.sc.sample :as samp]
-))
+            [overtone.sc.buffer :as buffer]))
 
 (def ^:dynamic *api-key* "47efd585321048819a2328721507ee23")
-
-(def supported-file-types ["wav" "aiff"])
 
 (defrecord-ifn FreesoundSample
   [id size n-channels rate status path args name freesound-id]
@@ -92,9 +90,10 @@
         name (:original_filename info)
         url  (sound-serve-url id)]
     (if (or (not type)
-            (some #{type} supported-file-types))
+            (some #{type} buffer/supported-file-types))
       (asset/asset-path url name)
-      (throw (Exception. (str "Invalid sample type: \"" type "\", only " supported-file-types " are supported."))))))
+      (throw (Exception. (str "Invalid sample type: \"" type "\", only " buffer/supported-file-types " are supported."))))))
+
 
 (defn freesound-sample
   "Download, cache and persist the freesound audio file specified by

--- a/src/overtone/sc/buffer.clj
+++ b/src/overtone/sc/buffer.clj
@@ -8,6 +8,8 @@
         [overtone.helpers audio-file lib file doc]
         [overtone.sc.util :only [id-mapper]]))
 
+(def supported-file-types ["wav" "aiff"])
+
 (defn- emit-inactive-buffer-modification-error
   "The default error behaviour triggered when a user attempts to work
    with an inactive buffer"
@@ -146,7 +148,7 @@
          (let [info                              (buffer-info id)
                {:keys [id size rate n-channels]} info]
            (when (every? zero? [size rate n-channels])
-             (throw (Exception. (str "Unable to read file - perhaps path is not a valid audio file (only .wav or .aiff supported) : " path))))
+             (throw (Exception. (str "Unable to read file - perhaps path is not a valid audio file (only " supported-file-types " supported) : " path))))
 
            (map->BufferFile
             (assoc info


### PR DESCRIPTION
## Why?
- The error on a bad freesound/sample does not tell you about the valid file types.
- We have to wait till after the download of the freesound file to find out its invalid.
## Solution
1. List the valid file types in the error message.
2. Check the file type before download from freesound.

I don't know how complete the type info is on Freesound so if type is not present pass it through (and the buffer loading will raise an error).
## Goal

Help newcomers quickly learn what they can and cannot use from freesound.
