### PR TITLE
Getting tests to run (a little bit closer)

### DIFF
--- a/test/overtone/event_test.clj
+++ b/test/overtone/event_test.clj
@@ -13,7 +13,7 @@
     (Thread/sleep 100)
     (is (= 2 @counter))
 
-    (remove-handler :b)
+    (remove-event-handler :b)
     (event :test-event)
     (Thread/sleep 100)
     (is (= 3 @counter))
@@ -25,7 +25,7 @@
     (Thread/sleep 100)
     (is (= 7 @counter))
 
-    (remove-event-handlers :test-event)
+    (remove-event-handler :test-event)
     (event :test-event)
     (Thread/sleep 100)
     (is (= 7 @counter))))


### PR DESCRIPTION
I wanted to run some tests and found a few things broken. I've fixed a couple which gets the test run a little further.
Though it still dies on the undefined `hit` fn. 
