### PR TITLE
Possible bug in sync-event

### DIFF
--- a/src/overtone/libs/event.clj
+++ b/src/overtone/libs/event.clj
@@ -238,7 +238,7 @@
                               (map? (first args)))
                        (first args)
                        (apply hash-map args))]
-      (apply handlers/sync-event handler-pool event-type event-info))))
+      (handlers/sync-event handler-pool event-type event-info))))
 
 (defn event-debug-on
   "Prints out all incoming events to stdout. May slow things down."

--- a/test/overtone/event_test.clj
+++ b/test/overtone/event_test.clj
@@ -73,8 +73,8 @@
   (let [fires (atom nil)]
     (on-sync-event :test-event #(swap! fires conj %) :test-event-key)
     (sync-event :test-event {:a "foo"
-                        :b "bar"
-                        :c "baz"})
+                             :b "bar"
+                             :c "baz"})
 
     (Thread/sleep 100)
 

--- a/test/overtone/event_test.clj
+++ b/test/overtone/event_test.clj
@@ -35,7 +35,7 @@
     (is (= 7 @counter))))
 
 (deftest fire-many-args-async-test
-  (let [fires (atom nil)]
+  (let [fires (atom [])]
     (on-event :test-event #(swap! fires conj %) :test-event-key)
     (event :test-event :a "foo" :b "bar" :c "baz")
 
@@ -48,7 +48,7 @@
     (remove-event-handler :test-event-key)))
 
 (deftest fire-map-arg-async-test
-  (let [fires (atom nil)]
+  (let [fires (atom [])]
     (on-event :test-event #(swap! fires conj %) :test-event-key)
     (event :test-event {:a "foo"
                         :b "bar"
@@ -63,7 +63,7 @@
     (remove-event-handler :test-event-key)))
 
 (deftest fire-many-args-sync-test
-  (let [fires (atom nil)]
+  (let [fires (atom [])]
     (on-sync-event :test-event #(swap! fires conj %) :test-event-key)
     (sync-event :test-event :a "foo" :b "bar" :c "baz")
 

--- a/test/overtone/event_test.clj
+++ b/test/overtone/event_test.clj
@@ -67,8 +67,6 @@
     (on-sync-event :test-event #(swap! fires conj %) :test-event-key)
     (sync-event :test-event :a "foo" :b "bar" :c "baz")
 
-    (Thread/sleep 100)
-
     (is (= @fires [{:a "foo"
                     :b "bar"
                     :c "baz"}]))
@@ -81,8 +79,6 @@
     (sync-event :test-event {:a "foo"
                              :b "bar"
                              :c "baz"})
-
-    (Thread/sleep 100)
 
     (is (= @fires [{:a "foo"
                     :b "bar"

--- a/test/overtone/event_test.clj
+++ b/test/overtone/event_test.clj
@@ -43,7 +43,9 @@
 
     (is (= @fires [{:a "foo"
                     :b "bar"
-                    :c "baz"}]))))
+                    :c "baz"}]))
+
+    (remove-event-handler :test-event-key)))
 
 (deftest fire-map-arg-async-test
   (let [fires (atom nil)]
@@ -56,7 +58,9 @@
 
     (is (= @fires [{:a "foo"
                     :b "bar"
-                    :c "baz"}]))))
+                    :c "baz"}]))
+
+    (remove-event-handler :test-event-key)))
 
 (deftest fire-many-args-sync-test
   (let [fires (atom nil)]
@@ -67,7 +71,9 @@
 
     (is (= @fires [{:a "foo"
                     :b "bar"
-                    :c "baz"}]))))
+                    :c "baz"}]))
+
+    (remove-event-handler :test-event-key)))
 
 (deftest fire-map-arg-sync-test
   (let [fires (atom nil)]
@@ -80,7 +86,9 @@
 
     (is (= @fires [{:a "foo"
                     :b "bar"
-                    :c "baz"}]))))
+                    :c "baz"}]))
+
+    (remove-event-handler :test-event-key)))
       
 (defn event-tests []
   (binding [*test-out* *out*]


### PR DESCRIPTION
`(event)` doesn't use `apply` when using `overtone.libs.handlers`, but `(sync-event)` does. I've got a feeling it shouldn't be there.
