### PR TITLE
Fix nanoKONTROL2 set-external-led-mode! so there is no crash when (connect) is called

### DIFF
--- a/src/overtone/device/midi/nanoKONTROL2.clj
+++ b/src/overtone/device/midi/nanoKONTROL2.clj
@@ -169,15 +169,12 @@
   control over the device.
 
   To enable external led mode, we need to send send the magical sysex
-  incantation to the nanoKontrol2 midi-out object nko (this was
+  incantation to the nanoKontrol2 midi-out object :out (this was
   determined by recording the sysex messages that the official Korg
-  Kontrol Editor sends to perform this task.)
-
-  On OS X, this is currently broken due to broken Java support for MIDI
-  sysex messages."
-  [nko]
+  Kontrol Editor sends to perform this task.)"
+  [out]
    (doseq [m [sysex-1 sysex-2 sysex-3 sysex-4 sysex-5 sysex-6]]
-     (midi-sysex (:out nko) m)))
+     (midi-sysex out m)))
 
 (defn leds-on-test
   [nko]


### PR DESCRIPTION
Before this fix, the `connect` routine called `set-external-led-mode!` with the `out` parameter.  But, the `set-external-led-mode!` code tries to dereference that via `(:out nko)` which returns nil and causes troubles when that is used in the `midi-sysex` call.   

This patch changes `set-external-led-mode!` to expect an `out` input and pass that to `midi-sysex`.  With this fix, the call to `(connect)` now works for me.
