### PR TITLE
Add functions to determine phase within beat/bar

### DIFF
--- a/src/overtone/music/rhythm.clj
+++ b/src/overtone/music/rhythm.clj
@@ -19,9 +19,13 @@
       (metro-beat [metro] [metro beat]
         "Returns the next beat number or the timestamp (in milliseconds) of the
      given beat.")
+      (metro-beat-phase [metro]
+        "Returns the distance traveled into the current beat [0.0, 1.0)")
       (metro-bar [metro] [metro  bar]
     "Returns the next bar number or the timestamp (in milliseconds) of the
      given bar")
+      (metro-bar-phase [metro]
+        "Returns the distance traveled into the current bar [0.0, 1.0)")
       (metro-bpb [metro] [metro new-bpb]
     "Get the current beats per bar or change it to new-bpb")
       (metro-bpm [metro] [metro new-bpm]
@@ -62,8 +66,14 @@
   (metro-tock  [metro] (beat-ms @bpb @bpm))
   (metro-beat  [metro] (inc (long (/ (- (now) @start) (metro-tick metro)))))
   (metro-beat  [metro b] (+ (* b (metro-tick metro)) @start))
+  (metro-beat-phase [metro]
+    (let [ratio (/ (- (now) @start) (metro-tick metro))]
+      (- (float ratio) (long ratio))))
   (metro-bar   [metro] (inc (long (/ (- (now) @bar-start) (metro-tock metro)))))
   (metro-bar   [metro b] (+ (* b (metro-tock metro)) @bar-start))
+  (metro-bar-phase [metro]
+    (let [ratio (/ (- (now) @start) (metro-tock metro))]
+      (- (float ratio) (long ratio))))
   (metro-bpm   [metro] @bpm)
   (metro-bpm   [metro new-bpm]
     (let [cur-beat      (metro-beat metro)

--- a/src/overtone/music/rhythm.clj
+++ b/src/overtone/music/rhythm.clj
@@ -2,7 +2,7 @@
   ^{:doc "Functions to help work with musical time."
      :author "Jeff Rose"}
   overtone.music.rhythm
-  (:use [overtone.music time]))
+  (:require [overtone.at-at :refer [now]]))
 
 (defonce ^{:private true}
   _PROTOCOLS_


### PR DESCRIPTION
I am writing a lighting control framework in Clojure, and the Overtone metronome object is almost perfect, but I needed a way to be able to tell how far into a beat or bar we have reached at the current moment (for doing things like pulsing lights in time to the music). This request adds that capability, as well as simplifying the namespace declaration to pull in only the specific function that it needs. Feel free to omit that second commit if you otherwise like this pull request.
