### PR TITLE
Keep metronome consistent under multithreading

### DIFF
--- a/src/overtone/music/rhythm.clj
+++ b/src/overtone/music/rhythm.clj
@@ -50,39 +50,65 @@
   IMetronome
   (metro-start [metro] @start)
   (metro-start [metro start-beat]
-    (let [new-start (- (now) (* start-beat (metro-tick metro)))]
-      (reset! start new-start)
-      new-start))
+    (dosync
+     (ensure bpm)
+     (let [new-start (- (now) (* start-beat (metro-tick metro)))]
+       (ref-set start new-start)
+       new-start)))
   (metro-bar-start [metro] @bar-start)
   (metro-bar-start [metro start-bar]
-    (let [new-bar-start (- (now) (* start-bar (metro-tock metro)))]
-      (reset! bar-start new-bar-start)
-      new-bar-start))
+    (dosync
+     (ensure bpm)
+     (ensure bpb)
+     (let [new-bar-start (- (now) (* start-bar (metro-tock metro)))]
+       (ref-set bar-start new-bar-start)
+       new-bar-start)))
   (metro-tick  [metro] (beat-ms 1 @bpm))
-  (metro-tock  [metro] (beat-ms @bpb @bpm))
-  (metro-beat  [metro] (inc (long (/ (- (now) @start) (metro-tick metro)))))
-  (metro-beat  [metro b] (+ (* b (metro-tick metro)) @start))
-  (metro-bar   [metro] (inc (long (/ (- (now) @bar-start) (metro-tock metro)))))
-  (metro-bar   [metro b] (+ (* b (metro-tock metro)) @bar-start))
+  (metro-tock  [metro] (dosync
+                        (ensure bpm)
+                        (ensure bpb)
+                        (beat-ms @bpb @bpm)))
+  (metro-beat  [metro] (dosync
+                        (ensure start)
+                        (ensure bpm)
+                        (inc (long (/ (- (now) @start) (metro-tick metro))))))
+  (metro-beat  [metro b] (dosync
+                          (ensure start)
+                          (ensure bpm)
+                          (+ (* b (metro-tick metro)) @start)))
+  (metro-bar   [metro] (dosync
+                        (ensure bar-start)
+                        (ensure bpm)
+                        (ensure bpb)
+                        (inc (long (/ (- (now) @bar-start) (metro-tock metro))))))
+  (metro-bar   [metro b] (dosync
+                          (ensure bar-start)
+                          (ensure bpm)
+                          (ensure bpb)
+                          (+ (* b (metro-tock metro)) @bar-start)))
   (metro-bpm   [metro] @bpm)
   (metro-bpm   [metro new-bpm]
-    (let [cur-beat      (metro-beat metro)
-          cur-bar       (metro-bar metro)
-          new-tick      (beat-ms 1 new-bpm)
-          new-tock      (* @bpb new-tick)
-          new-start     (- (metro-beat metro cur-beat) (* new-tick cur-beat))
-          new-bar-start (- (metro-bar metro cur-bar) (* new-tock cur-bar))]
-      (reset! start new-start)
-      (reset! bar-start new-bar-start)
-      (reset! bpm new-bpm))
+    (dosync
+     (ensure bpb)
+     (let [cur-beat      (metro-beat metro)
+           cur-bar       (metro-bar metro)
+           new-tick      (beat-ms 1 new-bpm)
+           new-tock      (* @bpb new-tick)
+           new-start     (- (metro-beat metro cur-beat) (* new-tick cur-beat))
+           new-bar-start (- (metro-bar metro cur-bar) (* new-tock cur-bar))]
+       (ref-set start new-start)
+       (ref-set bar-start new-bar-start)
+       (ref-set bpm new-bpm)))
     [:bpm new-bpm])
   (metro-bpb   [metro] @bpb)
   (metro-bpb   [metro new-bpb]
-    (let [cur-bar       (metro-bar metro)
-          new-tock      (beat-ms new-bpb @bpm)
-          new-bar-start (- (metro-bar metro cur-bar) (* new-tock cur-bar))]
-      (reset! bar-start new-bar-start)
-      (reset! bpb new-bpb)))
+    (dosync
+     (ensure bpm)
+     (let [cur-bar       (metro-bar metro)
+           new-tock      (beat-ms new-bpb @bpm)
+           new-bar-start (- (metro-bar metro cur-bar) (* new-tock cur-bar))]
+       (ref-set bar-start new-bar-start)
+       (ref-set bpb new-bpb))))
 
   clojure.lang.ILookup
   (valAt [this key] (.valAt this key nil))
@@ -116,10 +142,10 @@
   (m :bpm)     ; => return the current bpm val
   (m :bpm 140) ; => set bpm to 140"
   [bpm]
-  (let [start (atom (now))
-        bar-start (atom @start)
-        bpm   (atom bpm)
-        bpb   (atom 4)]
+  (let [start (ref (now))
+        bar-start (ref @start)
+        bpm   (ref bpm)
+        bpb   (ref 4)]
     (Metronome. start bar-start bpm bpb)))
 
 ;== Grooves


### PR DESCRIPTION
As it stood, the metronome could become inconsistent when multiple threads are making changes to it at the same time, because it was using atoms for its internal state, and atoms only provide isolated consistency.

Since changes sometimes need to be made to multiple state items in a coordinated fashion, the metronome needs to instead use refs and Clojure's software transactional memory features. I discovered this problem because I am synchronizing a metronome to the BPM of DJ software using MIDI clock pulses, while also allowing the user to beat jump, or change attributes like beats-per-bar.