### PR TITLE
Fix node map controls example

### DIFF
--- a/src/overtone/examples/synthesis/demand.clj
+++ b/src/overtone/examples/synthesis/demand.clj
@@ -82,7 +82,7 @@
 
 ;(def generator-node (note-generator))
 ;(def beep-node (beep))
-;(node-map-controls beep-node 0 0)
+;(node-map-controls beep-node [0 0])
 ;(stop)
 
 (demo 4


### PR DESCRIPTION
As originally written, evaluating the expression on line 85 raised the exception below. Wrapping up the parameter number and bus number as a vector works. 

```
1. Caused by java.lang.IllegalArgumentException
   No single method: node_map_controls of interface:
   overtone.sc.node.IControllableNode found for function:
   node-map-controls of protocol: IControllableNode

                 Compiler.java: 3518  clojure.lang.Compiler$InvokeExpr/<init>
                 Compiler.java: 3725  clojure.lang.Compiler$InvokeExpr/parse
                 Compiler.java: 6646  clojure.lang.Compiler/analyzeSeq
                 Compiler.java: 6445  clojure.lang.Compiler/analyze
                 Compiler.java: 6406  clojure.lang.Compiler/analyze
                 Compiler.java: 5782  clojure.lang.Compiler$BodyExpr$Parser/parse
                 Compiler.java: 5217  clojure.lang.Compiler$FnMethod/parse
                 Compiler.java: 3846  clojure.lang.Compiler$FnExpr/parse
                 Compiler.java: 6642  clojure.lang.Compiler/analyzeSeq
                 Compiler.java: 6445  clojure.lang.Compiler/analyze
                 Compiler.java: 6700  clojure.lang.Compiler/eval
```
