### PR TITLE
a first try at porting to APIv2 of Freesound

### DIFF
--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -180,7 +180,7 @@
   (let [url (if (= URL (type url)) url (URL. url))
         con (.openConnection url)]
     (when *authorization-header*
-      (.setRequestProperty con "Authorization" *authorization-header*))
+      (.setRequestProperty con "Authorization" (*authorization-header*)))
     (.getContentLength con)))
 
 (defn- percentage-slices
@@ -246,7 +246,7 @@
         url         (URL. url)
         con         (.openConnection url)]
     (when *authorization-header*
-      (.setRequestProperty con "Authorization" *authorization-header*))
+      (.setRequestProperty con "Authorization" (*authorization-header*)))
     (.setReadTimeout con timeout)
     (with-open [in (.getInputStream con)
                 out (output-stream target-path)]
@@ -261,7 +261,7 @@
         con  (.openConnection url)
         size (remote-file-size url)]
     (when *authorization-header*
-      (.setRequestProperty con "Authorization" *authorization-header*))
+      (.setRequestProperty con "Authorization" (*authorization-header*)))
     (.setReadTimeout con timeout)
     (with-open [in (.getInputStream con)
                 out (StringWriter.)]

--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -434,4 +434,3 @@
   ([url path timeout n-retries wait-t]
      (print-download-file url)
      (download-file* url path timeout n-retries wait-t)))
-

--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -11,6 +11,7 @@
             [clojure.string :as str]))
 
 (def ^{:dynamic true} *verbose-overtone-file-helpers* false)
+(def ^{:dynamic true} *authorization-header* false)
 
 (defn get-current-directory []
   (. (java.io.File. ".") getCanonicalPath))
@@ -178,6 +179,8 @@
   [url]
   (let [url (if (= URL (type url)) url (URL. url))
         con (.openConnection url)]
+    (when *authorization-header*
+      (.setRequestProperty con "Authorization" *authorization-header*))
     (.getContentLength con)))
 
 (defn- percentage-slices
@@ -242,6 +245,8 @@
         size        (remote-file-size url)
         url         (URL. url)
         con         (.openConnection url)]
+    (when *authorization-header*
+      (.setRequestProperty con "Authorization" *authorization-header*))
     (.setReadTimeout con timeout)
     (with-open [in (.getInputStream con)
                 out (output-stream target-path)]
@@ -255,9 +260,12 @@
   (let [url  (URL. url)
         con  (.openConnection url)
         size (remote-file-size url)]
+    (when *authorization-header*
+      (.setRequestProperty con "Authorization" *authorization-header*))
     (.setReadTimeout con timeout)
     (with-open [in (.getInputStream con)
                 out (StringWriter.)]
+      ;; NOTE: this seems broken when size is -1, which happens when getContentLength is absent
       (copy in out size)
       (.toString out))))
 
@@ -426,3 +434,4 @@
   ([url path timeout n-retries wait-t]
      (print-download-file url)
      (download-file* url path timeout n-retries wait-t)))
+

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -86,7 +86,10 @@
     (reset! *access-token* r)))
 
 (defn authorization-instructions []
-  (clojure.java.browse/browse-url (freesound-url "/oauth2/authorize/" {:client_id *client-id* :response_type "code"}))
+  (println "Authorize in browser and paste code in Stdin.")
+  (clojure.java.browse/browse-url
+   (freesound-url "/oauth2/authorize/"
+                  {:client_id *client-id* :response_type "code"}))
   (access-token (read-line)))
 
 (defmacro with-authorization-header [b]

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -8,6 +8,7 @@
         [overtone.helpers.lib :only [defrecord-ifn]]
         [overtone.helpers.file :only [*authorization-header*]])
   (:require [clojure.data.json :as json]
+            [clojure.java.browse]
             [overtone.libs.asset :as asset]
             [overtone.sc.sample :as samp]
             [overtone.sc.buffer :as buffer]))

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -86,11 +86,13 @@
     (reset! *access-token* r)))
 
 (defn authorization-instructions []
-  (println "Authorize in browser and paste code in Stdin.")
-  (clojure.java.browse/browse-url
-   (freesound-url "/oauth2/authorize/"
-                  {:client_id *client-id* :response_type "code"}))
-  (access-token (read-line)))
+  (let [url
+        (freesound-url "/oauth2/authorize/"
+                       {:client_id *client-id* :response_type "code"})]
+    (println "Authorize in browser and paste code in Stdin.")
+    (println url)
+    (clojure.java.browse/browse-url url)
+    (access-token (read-line))))
 
 (defmacro with-authorization-header [b]
   `(binding [*authorization-header*


### PR DESCRIPTION
Hi Sam,

This is more to start a discussion than to accept as is. I noticed that the Freesound API used by Overtone is now completely disabled on the Freesound website, which enforces the new version APIv2.

- a big inconvenience of the new version: the user has to authorize the application in order to get an access token -- does this step have to be interactive and through a browser?