### PR TITLE
Abort immediately after received 'File not found'

### DIFF
--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -398,6 +398,11 @@
      (let [path (resolve-tilde-path path)]
        (try
          (download-file-with-timeout url path timeout)
+         (catch java.io.FileNotFoundException e
+           (rm-rf! path)
+           (Thread/sleep wait-t)
+           (print-if-verbose (str "Download failed. File not found: " url ))
+           (throw (Exception. (str "Aborting! Download failed. File not found: " url ))))
          (catch Exception e
            (rm-rf! path)
            (Thread/sleep wait-t)


### PR DESCRIPTION
When I evaluate the following code, Overtone will not stop downloading (until 50-times) and I add an  exception clause for java.io.FileNotExcepiton.

`(def dirty-kick (freesound 30669))` in https://github.com/overtone/overtone/blob/master/src/overtone/examples/getting_started/pragpub-article.clj#L178
