### PR TITLE
fix #318 - prevent double trigger of freesound samples

### DIFF
--- a/src/overtone/sc/sample.clj
+++ b/src/overtone/sc/sample.clj
@@ -60,7 +60,7 @@
        values between 0 and 1). May be looped via the loop?
        argument. Release time is the release phase after the looping has
        finished to remove clipping."
-      [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 release 0.1 out-bus 0]
+      [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 release 0 out-bus 0]
       (let [n-frames  (buf-frames buf)
             rate      (* rate (buf-rate-scale buf))
             start-pos (* start n-frames)
@@ -77,7 +77,7 @@
        values between 0 and 1). May be looped via the loop?
        argument. Release time is the release phase after the looping has
        finished to remove clipping."
-      [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 release 0.1 out-bus 0]
+      [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 release 0 out-bus 0]
       (let [n-frames  (buf-frames buf)
             rate      (* rate (buf-rate-scale buf))
             start-pos (* start n-frames)


### PR DESCRIPTION
As suggested by @ormf in #318, I changed the default release to 0 for mono-partial-player and stereo-partial-player.

This fixes the issue with free sound samples being triggered twice.