### PR TITLE
Allow synth parameters to be specified in map.

### DIFF
--- a/src/overtone/sc/synth.clj
+++ b/src/overtone/sc/synth.clj
@@ -512,6 +512,10 @@
     (let [arg-names         (map keyword (map :name params))
           args              (or args [])
           [target pos args] (extract-target-pos-args args (foundation-default-group) :tail)
+          args              (if (and (= (count args) 1)
+                                     (map? (first args)))
+                              (flatten (seq (first args)))
+                              args)
           args              (idify args)
           args              (map (fn [arg] (if-let [id (:id arg)]
                                             id


### PR DESCRIPTION
Workaround for #282.
Suggested here: https://groups.google.com/forum/#!topic/overtone/agcjQc-ztUU

Tested with both synths and instruments. Appears to work well.

``` clojure
(definst foo [freq 440] (sin-osc freq))

;; the following are all now equivalent
(foo 330)
(foo :freq 330)
(foo {:freq 330})
```
