### PR TITLE
Clojure 1.9 compat: exclude Inst and inst?

### DIFF
--- a/src/overtone/repl/inst.clj
+++ b/src/overtone/repl/inst.clj
@@ -1,4 +1,5 @@
 (ns overtone.repl.inst
+  (:refer-clojure :exclude [inst?])
   (:use [overtone.studio.inst :only (inst?)]))
 
 (defn ns-instruments
@@ -22,4 +23,3 @@
   [ns]
   (for [[n v] (ns-publics ns) :when (inst? @v)]
     @v))
-

--- a/src/overtone/studio/inst.clj
+++ b/src/overtone/studio/inst.clj
@@ -1,4 +1,5 @@
 (ns overtone.studio.inst
+  (:refer-clojure :exclude [Inst inst?])
   (:use [overtone.sc defaults bindings server synth ugens envelope node bus dyn-vars]
         [overtone.sc.machinery synthdef]
         [overtone.sc.machinery.server.comms :only [with-server-sync]]


### PR DESCRIPTION
Clojure 1.9 introduces clojure.core/Inst and clojure.core/inst?, and these clash
with overtone.studio.inst/Inst and overtone.studio.inst/inst?.

This patch adds `:refer-clojure :exclude [Inst inst?]`, you still get warnings
when requiring overtone.live, but it no longer blows up.