### PR TITLE
Exclude inst? from overtone.live as well

### DIFF
--- a/src/overtone/live.clj
+++ b/src/overtone/live.clj
@@ -1,4 +1,5 @@
 (ns overtone.live
+  (:refer-clojure :exclude [inst?])
   (:require [overtone.api]))
 
 (overtone.api/immigrate-overtone-api)


### PR DESCRIPTION
Sorry, misssed this one the first time. Now you can `(require 'overtone.live)` without warnings.