### PR TITLE
Clojure 1.9.0 compatibility - use :use and :import keyword forms in ns declarations

### DIFF
--- a/src/overtone/samples/freesound/url.clj
+++ b/src/overtone/samples/freesound/url.clj
@@ -3,7 +3,7 @@
   overtone.samples.freesound.url
   (:use [clojure.walk :only [keywordize-keys]])
   (:require [clojure.string :as str])
-  (import [java.net URLEncoder URLDecoder]))
+  (:import [java.net URLEncoder URLDecoder]))
 
 (defn url-encode [s & [encoding]]
   (URLEncoder/encode s (or encoding "UTF-8")))

--- a/src/overtone/sc/foundation_groups.clj
+++ b/src/overtone/sc/foundation_groups.clj
@@ -2,13 +2,13 @@
     ^{:doc "Foundation Group Structure"
       :author "Sam Aaron"}
   overtone.sc.foundation-groups
-  (use [overtone.libs.deps                 :only [on-deps satisfy-deps]]
-       [overtone.libs.event                :only [on-sync-event]]
-       [overtone.sc.node                   :only [group group-deep-clear group-clear]]
-       [overtone.sc.server                 :only [ensure-connected!]]
-       [overtone.sc.defaults               :only [foundation-groups* empty-foundation-groups]]
-       [overtone.sc.server                 :only [clear-msg-queue]]
-       [overtone.sc.machinery.server.comms :only [with-server-sync]]))
+  (:use [overtone.libs.deps                 :only [on-deps satisfy-deps]]
+        [overtone.libs.event                :only [on-sync-event]]
+        [overtone.sc.node                   :only [group group-deep-clear group-clear]]
+        [overtone.sc.server                 :only [ensure-connected!]]
+        [overtone.sc.defaults               :only [foundation-groups* empty-foundation-groups]]
+        [overtone.sc.server                 :only [clear-msg-queue]]
+        [overtone.sc.machinery.server.comms :only [with-server-sync]]))
 
 (defn- setup-foundation-groups
   []


### PR DESCRIPTION
Since clojure.specs for `ns` were added in the 1.9.0 alphas requiring overtone failed at runtime due to:

```
ExceptionInfo Call to clojure.core/ns did not conform to spec:
In: [1] val: ((use [overtone.libs.deps :only [on-deps satisfy-deps]])) fails at: [:args] predicate: (cat :docstring (? string?) :attr-map (? map?) :clauses :clojure.core.specs/ns-clauses),  Extra input
```

This PR replaces `use` and `import` to their keyword forms in `ns` declarations.