### PR TITLE
overtone/at-at is not in central repo 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/data.json "0.2.3"]
                  [clj-native "0.9.3"]
-                 [overtone/at-at "1.2.0"]
+                 [org.clojars.arewaolakunle/at-at "1.2.0"]
                  [overtone/osc-clj "0.9.0"]
                  [overtone/byte-spec "0.3.1"]
                  [overtone/midi-clj "0.5.0"]


### PR DESCRIPTION
This seems to work to solve #377 