### PR TITLE
Fixed #381. weighted-sum now uses == to check probabilities sum to 1

### DIFF
--- a/src/overtone/algo/chance.clj
+++ b/src/overtone/algo/chance.clj
@@ -36,7 +36,7 @@
                                (count vals)
                                " and "
                                (count probabilities)))))
-     (when-not (= (reduce + probabilities) 1.0)
+     (when-not (== (reduce + probabilities) 1.0)
        (throw (IllegalArgumentException. (str "The sum of your probabilities is not 1.0"))))
 
      (let [paired (map vector probabilities vals)


### PR DESCRIPTION
This fixes issues #381.

`overtone.algo.chance/weighted-sum` now uses `==` to check probabilities sum to 1.