### PR TITLE
major version bump and remove precompiled libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ target/
 /.classpath
 /bin
 /.settings
+.nrepl-port

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
             :distribution :repo
             :comments "Please use Overtone for good"}
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/data.json "0.2.3"]
                  [clj-native "0.9.3"]
                  [overtone/at-at "1.2.0"]
@@ -58,8 +58,6 @@
                  [overtone/byte-spec "0.3.1"]
                  [overtone/midi-clj "0.5.0"]
                  [overtone/libs.handlers "0.2.0"]
-                 [overtone/scsynth "3.5.7.0"]
-                 [overtone/scsynth-extras "3.5.7.0"]
                  [clj-glob "1.0.0"]]
   :profiles {:test {:dependencies [[bultitude "0.2.0"]
                                    [polynome "0.2.2"]]}}

--- a/src/overtone/sc/machinery/server/args.clj
+++ b/src/overtone/sc/machinery/server/args.clj
@@ -47,10 +47,12 @@
   trying both and examining the output from the successful run. Returns a float
   representing major and minor release" 
   []
-  (let [attempts [(sh "scsynth" "-V") (sh "scsynth" "-v")]
-        successful (first (filter #(= (:exit %) 0) attempts))
-        version (re-find #"scsynth\s+(\d+\.\d+)\.\d+" (:out successful))
-        ]
+  (let [attempt (sh "scsynth" "-v")
+        _ (when (not= 0 (:exit attempt))
+            (throw (Exception. (str "scsynth was not found, "
+                                    "please make sure that "
+                                    "Supercollider is installed."))))
+        version (re-find #"scsynth\s+(\d+\.\d+)" (:out attempt))]
     (Float. (last version))))
 
 (defn- fix-verbosity-flag

--- a/src/overtone/sc/machinery/server/connection.clj
+++ b/src/overtone/sc/machinery/server/connection.clj
@@ -198,11 +198,6 @@
 (defn- boot-internal-server
   "Boots internal server by executing it on a daemon thread."
   [opts]
-  (when-not  (native-scsynth-available?)
-    (dosync
-     (ref-set connection-status* :disconnected))
-    (throw (Exception. (str "Can't connect to native server - no compatible libraries for your system are available: " (get-cpu-bits) "-bit " (name (get-os)) "." ))))
-
   (let [sc-thread (Thread. #(internal-booter opts))]
     (.setDaemon sc-thread true)
     (println "--> Booting internal SuperCollider server...")

--- a/src/overtone/sc/machinery/server/native.clj
+++ b/src/overtone/sc/machinery/server/native.clj
@@ -6,15 +6,15 @@
         [overtone.helpers.system :only [get-os get-cpu-bits windows-os? os-description]]
         [overtone.sc.machinery.server args]
         [overtone.sc.defaults :only [INTERNAL-POOL]]
-        [overtone.nativescsynth.availability :only [native-scsynth-lib-availability]]
+        ;; [overtone.nativescsynth.availability :only [native-scsynth-lib-availability]]
         [clj-native.direct :only [defclib loadlib]]
         [clj-native.structs :only [byref]]
         [clj-native.callbacks :only [callback]]
         [overtone.config.log :only [warn error]]))
 
-(defn native-scsynth-available? []
-  (let [os-arc-path [(get-os) (get-cpu-bits)]]
-    (get-in native-scsynth-lib-availability os-arc-path)))
+#_(defn native-scsynth-available? []
+    (let [os-arc-path [(get-os) (get-cpu-bits)]]
+      (get-in native-scsynth-lib-availability os-arc-path)))
 
 (declare world-options)
 (declare reply-callback)
@@ -31,144 +31,142 @@
         (:functions
          (fflush fflush [void*] i32))))
 
-    (when (native-scsynth-available?)
-      (defclib
-        lib-scsynth
-        (:libname "scsynth")
-        (:structs
-         (rate
-          :sample-rate double
-          :buf-rate    double
-          :radians-per-sample double)
+    (defclib
+      lib-scsynth
+      (:libname "scsynth")
+      (:structs
+       (rate
+        :sample-rate double
+        :buf-rate    double
+        :radians-per-sample double)
 
-         ;; supercollider/include/server/SC_WorldOptions.h
-         (world-options
-          :mPassword                          constchar*
-          :mNumBuffers                        i32
-          :mMaxLogins                         i32
-          :mMaxNodes                          i32
-          :mMaxGraphDefs                      i32
-          :mMaxWireBufs                       i32
-          :mNumAudioBusChannels               i32
-          :mNumInputBusChannels               i32
-          :mNumOutputBusChannels              i32
-          :mNumControlBusChannels             i32
-          :mBufLength                         i32
-          :mRealTimeMemorySize                i32
-          :mNumSharedControls                 i32
-          :mSharedControls                    float*
-          :mRealTime                          byte
-          :mMemoryLocking                     byte
-          :mNonRealTimeCmdFilename            constchar*
-          :mNonRealTimeInputFilename          constchar*
-          :mNonRealTimeOutputFilename         constchar*
-          :mNonRealTimeOutputHeaderFormat     constchar*
-          :mNonRealTimeOutputSampleFormat     constchar*
-          :mPreferredSampleRate               i32
-          :mNumRGens                          i32
-          :mPreferredHardwareBufferFrameSize  i32
-          :mLoadGraphDefs                     i32
-          :mInputStreamsEnabled               constchar*
-          :mOutputStreamsEnabled              constchar*
-          :mInDeviceName                      constchar*
-          :mVerbosity                         i32
-          :mRendezvous                        byte
-          :mUGensPluginPath                   constchar*
-          :mOutDeviceName                     constchar*
-          :mRestrictedPath                    constchar*
-          :mSharedMemoryID                    i32)
+       ;; supercollider/include/server/SC_WorldOptions.h
+       (world-options
+        :mPassword                          constchar*
+        :mNumBuffers                        i32
+        :mMaxLogins                         i32
+        :mMaxNodes                          i32
+        :mMaxGraphDefs                      i32
+        :mMaxWireBufs                       i32
+        :mNumAudioBusChannels               i32
+        :mNumInputBusChannels               i32
+        :mNumOutputBusChannels              i32
+        :mNumControlBusChannels             i32
+        :mBufLength                         i32
+        :mRealTimeMemorySize                i32
+        :mNumSharedControls                 i32
+        :mSharedControls                    float*
+        :mRealTime                          byte
+        :mMemoryLocking                     byte
+        :mNonRealTimeCmdFilename            constchar*
+        :mNonRealTimeInputFilename          constchar*
+        :mNonRealTimeOutputFilename         constchar*
+        :mNonRealTimeOutputHeaderFormat     constchar*
+        :mNonRealTimeOutputSampleFormat     constchar*
+        :mPreferredSampleRate               i32
+        :mNumRGens                          i32
+        :mPreferredHardwareBufferFrameSize  i32
+        :mLoadGraphDefs                     i32
+        :mInputStreamsEnabled               constchar*
+        :mOutputStreamsEnabled              constchar*
+        :mInDeviceName                      constchar*
+        :mVerbosity                         i32
+        :mRendezvous                        byte
+        :mUGensPluginPath                   constchar*
+        :mOutDeviceName                     constchar*
+        :mRestrictedPath                    constchar*
+        :mSharedMemoryID                    i32)
 
-         ;; supercollider/include/plugin_interface/SC_SndBuf.h
-         (sound-buffer
-          :samplerate double
-          :sampledur  double
-          :data       void*             ;float*
-          :channels   i32
-          :samples    i32
-          :frames     i32
-          :mask       i32
-          :mask1      i32
-          :coord      i32
-          :sndfile    void*)
+       ;; supercollider/include/plugin_interface/SC_SndBuf.h
+       (sound-buffer
+        :samplerate double
+        :sampledur  double
+        :data       void*             ;float*
+        :channels   i32
+        :samples    i32
+        :frames     i32
+        :mask       i32
+        :mask1      i32
+        :coord      i32
+        :sndfile    void*)
 
-         (bool-val
-          :value byte)
+       (bool-val
+        :value byte)
 
-         ;; supercollider/include/plugin_interface/SC_World.h
-         (world
-          :hidden-world void*
-          :interface-table void*
-          :sample-rate double
-          :buf-length  i32
-          :buf-counter i32
-          :num-audio-bus-channels   i32
-          :num-control-bus-channels i32
-          :num-inputs               i32
-          :num-outputs              i32
-          :audio-busses             float*
-          :control-busses           float*
-          :audio-bus-touched        i32*
-          :control-bus-touched      i32*
-          :num-snd-bufs             i32
-          :snd-bufs                 sound-buffer*
-          :snd-bufs-non-realtime    sound-buffer*
-          :snd-buf-updates          void*
-          :top-group                void*
-          :full-rate                rate
-          :buf-rate                 rate
-          :num-rgens                i32
-          :rgen                     void*
-          :num-units                i32
-          :num-graphs               i32
-          :num-groups               i32
-          :sample-offset            i32
-          :nrt-lock                 void*
-          :num-shared-controls      i32
-          :shared-controls          float*
-          :real-time?               byte
-          :running?                 byte
-          :dump-osc                 i32
-          :driver-lock              void*
-          :subsample-offset         float
-          :verbosity                i32
-          :error-notification       i32
-          :local-error-notificaiton i32
-          :rendezvous?              byte
-          :restricted-path          constchar*)
+       ;; supercollider/include/plugin_interface/SC_World.h
+       (world
+        :hidden-world void*
+        :interface-table void*
+        :sample-rate double
+        :buf-length  i32
+        :buf-counter i32
+        :num-audio-bus-channels   i32
+        :num-control-bus-channels i32
+        :num-inputs               i32
+        :num-outputs              i32
+        :audio-busses             float*
+        :control-busses           float*
+        :audio-bus-touched        i32*
+        :control-bus-touched      i32*
+        :num-snd-bufs             i32
+        :snd-bufs                 sound-buffer*
+        :snd-bufs-non-realtime    sound-buffer*
+        :snd-buf-updates          void*
+        :top-group                void*
+        :full-rate                rate
+        :buf-rate                 rate
+        :num-rgens                i32
+        :rgen                     void*
+        :num-units                i32
+        :num-graphs               i32
+        :num-groups               i32
+        :sample-offset            i32
+        :nrt-lock                 void*
+        :num-shared-controls      i32
+        :shared-controls          float*
+        :real-time?               byte
+        :running?                 byte
+        :dump-osc                 i32
+        :driver-lock              void*
+        :subsample-offset         float
+        :verbosity                i32
+        :error-notification       i32
+        :local-error-notificaiton i32
+        :rendezvous?              byte
+        :restricted-path          constchar*)
 
-         (reply-address
-          :sockaddr     void*
-          :sockaddr-len i32
-          :socket       i32
-          :reply-func   void*
-          :reply-data   void*)
-         )
+       (reply-address
+        :sockaddr     void*
+        :sockaddr-len i32
+        :socket       i32
+        :reply-func   void*
+        :reply-data   void*)
+       )
 
-        (:callbacks
+      (:callbacks
 
-         ;; supercollider/include/common/SC_Reply.h
-         (reply-callback [void* void* i32] void))
+       ;; supercollider/include/common/SC_Reply.h
+       (reply-callback [void* void* i32] void))
 
-        ;; TODO: void* here is actually world*
-        (:functions
+      ;; TODO: void* here is actually world*
+      (:functions
 
-         ;; supercollider/include/server/SC_WorldOptions.h
-         (world-new World_New [world-options*] void*)
-         (world-run World_WaitForQuit [void*])
-         (world-cleanup World_Cleanup [void*])
+       ;; supercollider/include/server/SC_WorldOptions.h
+       (world-new World_New [world-options*] void*)
+       (world-run World_WaitForQuit [void*])
+       (world-cleanup World_Cleanup [void*])
 
-         (world-open-udp-port World_OpenUDP [void* i32] i32)
-         (world-open-tcp-port World_OpenTCP [void* i32 i32 i32] i32)
-         (world-send-packet World_SendPacket [void* i32 byte* reply-callback] byte)
-         (world-copy-sound-buffer World_CopySndBuf [void* i32 sound-buffer* byte byte*] i32)))
+       (world-open-udp-port World_OpenUDP [void* i32] i32)
+       (world-open-tcp-port World_OpenTCP [void* i32 i32 i32] i32)
+       (world-send-packet World_SendPacket [void* i32 byte* reply-callback] byte)
+       (world-copy-sound-buffer World_CopySndBuf [void* i32 sound-buffer* byte byte*] i32)))
 
-      (when-not (windows-os?)
-        (loadlib libc))
+    (when-not (windows-os?)
+      (loadlib libc))
 
-      (when (native-scsynth-available?)
-        (loadlib lib-scsynth))
+    (loadlib lib-scsynth)
 
-      (defonce flusher (at-at/every 500 #(fflush nil) INTERNAL-POOL :desc "Flush stdout")))
+    (defonce flusher (at-at/every 500 #(fflush nil) INTERNAL-POOL :desc "Flush stdout"))
     (catch UnsatisfiedLinkError e
       (warn (with-out-str (.printStackTrace e)))
       (error "Unable to load native libs c and scsynth. Please try an external server with (use 'overtone.core)"))))
@@ -218,19 +216,17 @@
   "Load libscsynth and start the synthesis server with the given options.  Returns
   the World pointer."
   ([recv-fn] (scsynth recv-fn {}))
-  ([recv-fn options-map]
-     (when (not (native-scsynth-available?))
-       (throw (Exception. (str "Can't connect to a native server - this version of Overtone does not yet have any compatible libraries for your system: " (os-description) ". Please consider contributing a build to the project."))))
-     (let [options (byref world-options)
-           cb      (callback reply-callback
-                             (fn [addr msg-buf msg-size]
-                               (let [byte-buf (.getByteBuffer msg-buf 0 msg-size)]
-                                 (recv-fn (.order byte-buf ByteOrder/BIG_ENDIAN)))))
+  ([recv-fn options-map]   
+   (let [options (byref world-options)
+         cb      (callback reply-callback
+                           (fn [addr msg-buf msg-size]
+                             (let [byte-buf (.getByteBuffer msg-buf 0 msg-size)]
+                               (recv-fn (.order byte-buf ByteOrder/BIG_ENDIAN)))))
 
-           args    (merge-native-sc-args options-map)]
-       (set-world-options! options args)
-       {:world (world-new options)
-        :callback cb})))
+         args    (merge-native-sc-args options-map)]
+     (set-world-options! options args)
+     {:world (world-new options)
+      :callback cb})))
 
 (defn scsynth-listen-udp
   [sc port]


### PR DESCRIPTION
So this was tested with the latest Supercollider (3.9.dev) on Fedora 25, with ALSA and JACK.

This pull request will remove precompiled Supercollider libraries from version 3.5x, that were compiled now 5 years ago (2012). Overtone will not make the checks if a native Supercollider was found on the system, if `scsynth -v` command fails, Overtone will throw an error, obviously at that point, we can be sure that Overtone won't find native Supercollider libraries.

If this gets accepted, last 5 years of clojure.core development becomes available at seemingly no tradeoff of incompatible backwards compatibility.

I hope users test this pull request and see if it works on their machine, I suspect Overtone is here compatible with SC3.6 up to newest gihub upstream 3.9dev.