### PR TITLE
Fix verbosity flag typo

### DIFF
--- a/src/overtone/sc/machinery/server/args.clj
+++ b/src/overtone/sc/machinery/server/args.clj
@@ -40,7 +40,7 @@
    :in-streams               {:default nil    :flag "-I" :desc "Input streams enabled"}
    :out-streams              {:default nil    :flag "-O" :desc "Output streams enabled"}
    :hw-device-name           {:default nil    :flag "-H" :desc "Hardware device name"}
-   :verbosity                {:default 0      :flag "-v" :desc "Verbosity mode. 0 is normal behaviour, -1 suppress information messages, -2 suppresses informational and many error messages"}
+   :verbosity                {:default 0      :flag "-V" :desc "Verbosity mode. 0 is normal behaviour, -1 suppress information messages, -2 suppresses informational and many error messages"}
    :ugens-paths              {:default nil    :flag "-U" :desc "A list of paths of ugen directories. If specified, the standard paths are NOT searched for plugins."}
    :restricted-path          {:default nil    :flag "-P" :desc "Prevents file-accesing OSC commands from accessing files outside the specified path."}})
 


### PR DESCRIPTION
This also fixes the following critical error on `(boot-external-server)` evaluation.

> Exception Error: unable to connect to externally booted server after 50 attempts.
>   overtone.sc.machinery.server.connection/external-connection-runner (connection.clj:153)

By the typo, SC servers started by `(boot-external-server)` show its version and immediately finish.

my env:
- Windows 10 (64 bit)
- Java HotSpot(TM) 64-Bit Server VM 9+181
- Clojure 1.9.0-RC2
- scsynth 3.8.0 (Built from branch '3.8' [0947edd])
- Overtone v0.10.3 (master 2852b695eb4f572dcc09ce8e25ccadc166003f28)

