### PR TITLE
Add missing parens in assoc call in studio/mixer

### DIFF
--- a/src/overtone/studio/mixer.clj
+++ b/src/overtone/studio/mixer.clj
@@ -203,11 +203,10 @@
                             #(group "Studio" :head root)
                             "whilst creating the Studio group")
         insts-with-groups (map-vals (fn [val]
-                                      assoc val
-                                      :group
-                                      (with-server-sync
-                                        #(group (str "Recreated Inst Group") :tail g)
-                                        "whist creating the Recreated Inst Group"))
+                                      (assoc val :group
+                                        (with-server-sync
+                                          #(group (str "Recreated Inst Group") :tail g)
+                                          "whist creating the Recreated Inst Group")))
                                     (:instruments @studio*))]
     (swap! studio* assoc
            :instrument-group g


### PR DESCRIPTION
The lack of parens around this assoc call causes definst/inst to throw an exception when called after the server is killed then started again. This error causes studio* to have the wrong shape after the server is booted a second time. The change in state before and after the reboot can be seen here:

```clojure
user=> (definst drum [] (sin-osc 440))
#<instrument: drum>
user=> (:group (get (:instruments @studio*) "drum"))
#<synth-group[live]: Inst drum Container 33>
user=> (kill-server)
:server-killed
user=> (boot-external-server)
...
user=> (definst drum [] (sin-osc 440))

CompilerException java.lang.IllegalArgumentException: No implementation of method: :to-sc-id of protocol: #'overtone.sc.node/to-sc-id* found for class: java.lang.String, compiling:(form-init33334487881954785.clj:1:1)
user=> (:group (get (:instruments @studio*) "drum"))
"Recreated Inst Group"
```