### PR TITLE
Parse the octave string with `Integer/parseInt`

### DIFF
--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -141,7 +141,7 @@
   [midi-string]
   (let [[match pitch-class octave] (validate-midi-string! midi-string)
         pitch-class                (canonical-pitch-class-name pitch-class)
-        octave                     (int octave)
+        octave                     (Integer/parseInt octave)
         interval                   (NOTES (keyword pitch-class))]
     {:match       match
      :pitch-class pitch-class


### PR DESCRIPTION
Fixes (again) #428.

The original parsing that used `(int ...)` doesn't seem to like strings from what I can tell.

My apologizes if I made a mistake somewhere in this, I'm a bit rushed ATM.