### PR TITLE
remove cruft, causing a syntax error

### DIFF
--- a/src/overtone/samples/piano.clj
+++ b/src/overtone/samples/piano.clj
@@ -20,9 +20,6 @@
 
 (def PIANO-SAMPLE-IDS (keys FREESOUND-PIANO-SAMPLES))
 
-#_(defonce piano-samples
-    (doall (map freesound-sample PIANO-SAMPLE-IDS)))
-
 (defonce piano-samples
   (apply freesound-samples PIANO-SAMPLE-IDS))
 


### PR DESCRIPTION
This change seems necessary to me to be able to load the piano samples.