### PR TITLE
Fix broken version comparison in args/SC-ARG-INFO

### DIFF
--- a/src/overtone/sc/machinery/server/args.clj
+++ b/src/overtone/sc/machinery/server/args.clj
@@ -54,14 +54,14 @@
              version-regex [(re-find #"scsynth\s+(\d+\.\d+)\.\d+" (:out successful))
                             (re-find #"scsynth\s+(\d+\.\d+)" (:out successful))]
              version (->> version-regex (remove nil?) (map second) (filter numeric?) first)]
-         (read-string version))
-       (catch Exception e 3.9)))
+         (mapv #(Integer/parseInt %) (string/split version #"\.")))
+       (catch Exception e [3 9])))
 
 (defn- fix-verbosity-flag
   "If scsynth version is 3.7 or above, upper-case the :flag in the :verbosity
   arg"
   [args]
-  (if (< 3.6 (find-sc-version))
+  (if (neg? (compare [3 6] (find-sc-version)))
     (update-in args [:verbosity] assoc :flag (clojure.string/upper-case (:flag (:verbosity args))))
     args))
 


### PR DESCRIPTION
The previous logic in the modified code compares the major and minor
portions of the supercollider version by converting the version string
to a floating point number and comparing it to a numeric constant. This
comparison breaks when upgrading to supercollider `3.10` because `(< 3.6
3.10)` is false.

This commit changes the comparison to use a sequence of integers in a
vector, such as `[3 10]`. This data structure can be compared using the
`compare` function resulting in semantics that match how semantic
versions are compared.

```
(neg? (compare [3 6] [3 5]))  ; => false
(neg? (compare [3 6] [3 6]))  ; => false
(neg? (compare [3 6] [3 9]))  ; => true
(neg? (compare [3 6] [3 10])) ; => true
```