### PR TITLE
Removing "?" and "=" from default output file name when fetching url

### DIFF
--- a/src/overtone/libs/asset.clj
+++ b/src/overtone/libs/asset.clj
@@ -101,7 +101,7 @@
 (defn asset-path
   "Given a url will return a path to a copy of the asset on the local file
   system. Will download and persist the asset if necessary."
-  ([url] (asset-path url (last (split url #"/"))))
+  ([url] (asset-path url (safe-url (last (split url #"/")))))
   ([url name]
      (if-let [path (fetch-cached-path url name)]
        path


### PR DESCRIPTION
This one fixes #458 