### PR TITLE
Fixed broken freesound link and broken args

### DIFF
--- a/src/overtone/examples/compositions/clapping_music.clj
+++ b/src/overtone/examples/compositions/clapping_music.clj
@@ -5,8 +5,8 @@
 (ns overtone.examples.compositions.clapping-music
   (:use overtone.live))
 
-(def clap (freesound 48310))
-(def clap2 (freesound 132676))
+(def clap (freesound 436674))
+(def clap2 (freesound 3718))
 ;(clap)
 ;(clap2)
 
@@ -24,9 +24,9 @@
   (dorun (map (fn [i]
                 (let [v (if (= 0 (mod i 3)) 1 0.5)]
                   (when (= (pattern-1 i) 1)
-                    (at (m (+ (/ i 12.0) beat)) (clap 1 0 0 (* v 0.33))))
+                    (at (m (+ (/ i 12.0) beat)) (clap 1 0 1 0 (* v 0.33))))
                   (when (= (pattern-2 i) 1)
-                    (at (m (+ (/ i 12.0) beat)) (clap2 1 0 0 v)))))
+                    (at (m (+ (/ i 12.0) beat)) (clap2 1 0 1 0 v)))))
               (range 12))))
 
 (defn player [beat]


### PR DESCRIPTION
This PR fixes issues #463 and #465 which prevented `overtone.examples.compositions.clapping-music` from being playable.

The playback is still 'clicky' due to sample playback, and I'm not sure how to fix this. I tried using `load-sample` and `play-buf` as suggested [here](https://github.com/overtone/overtone/issues/421) but I couldn't find a way to change the volume of each sample playback.