### PR TITLE
remove `:tag` from badigeon/badigeon lib dep; it mismatches the git sha

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,5 +13,4 @@
          clj-glob/clj-glob {:mvn/version "1.0.0"}
          clj-native/clj-native {:mvn/version "0.9.5"}
          badigeon/badigeon {:git/url "https://github.com/EwenG/badigeon.git"
-                            :sha "55360471a57ad982ac89792c895933e1d2239625"
-                            :tag "1.0"}}}
+                            :sha "55360471a57ad982ac89792c895933e1d2239625"}}}


### PR DESCRIPTION
without this change I get
```
Error building classpath. Library badigeon/badigeon has sha and tag that point to different commits
```
when trying to start a repl with overtone as a dependency.

Might also be nice to get a release out with this + https://github.com/overtone/overtone/commit/02f8cdd2817bf810ff390b6f91d3e84d61afcc85 because I spent a long while battling
```
Unhandled clojure.lang.Compiler$CompilerException
Syntax error compiling at (badigeon/bundle.clj:1:1).
{:clojure.error/phase :compile-syntax-check, :clojure.error/line 1, :clojure.error/column 1, :clojure.error/source "badigeon/bundle.clj"}
Unhandled java.io.FileNotFoundException
Could not locate clojure/tools/deps/alpha/reader__init.class, clojure/tools/deps/alpha/reader.clj or clojure/tools/deps/alpha/reader.cljc on classpath.
```

while running the latest released version only to eventually find that it had been fixed on to the main branch but not yet released