### PR TITLE
Fix window paths to allow downloading samples

### DIFF
--- a/src/overtone/config/store.clj
+++ b/src/overtone/config/store.clj
@@ -5,7 +5,7 @@
   (:use [overtone.config.file-store]
         [overtone.helpers.string :only [capitalize]]
         [overtone.helpers.system :only [get-os system-user-name]]
-        [overtone.helpers.file :only [mkdir! file-exists? path-exists? mv!]]
+        [overtone.helpers.file :only [mkdir! file-exists? path-exists? mv! mk-path]]
         [overtone version]
         [clojure.java.io :only [delete-file]]))
 
@@ -69,19 +69,19 @@
   @live-store)
 
 (def OVERTONE-DIRS
-  (let [root   (str (System/getProperty "user.home") "/.overtone")
-        log    (str root "/log")
-        assets (str root "/assets")
-        speech (str root "/speech")]
+  (let [root   (mk-path (System/getProperty "user.home") ".overtone")
+        log    (mk-path root "log")
+        assets (mk-path root "assets")
+        speech (mk-path root "speech")]
       {:root root
        :log log
        :assets assets
        :speech speech}))
 
-(def OVERTONE-CONFIG-FILE     (str (:root   OVERTONE-DIRS) "/config.clj"))
-(def OVERTONE-USER-STORE-FILE (str (:root   OVERTONE-DIRS) "/user-store.clj"))
-(def OVERTONE-ASSETS-FILE     (str (:assets OVERTONE-DIRS) "/assets.clj"))
-(def OVERTONE-LOG-FILE        (str (:log    OVERTONE-DIRS) "/overtone.log"))
+(def OVERTONE-CONFIG-FILE     (mk-path (:root   OVERTONE-DIRS) "config.clj"))
+(def OVERTONE-USER-STORE-FILE (mk-path (:root   OVERTONE-DIRS) "user-store.clj"))
+(def OVERTONE-ASSETS-FILE     (mk-path (:assets OVERTONE-DIRS) "assets.clj"))
+(def OVERTONE-LOG-FILE        (mk-path (:log    OVERTONE-DIRS) "overtone.log"))
 
 (defn- ensure-dir-structure
   []
@@ -121,7 +121,7 @@
 
 (defonce __MOVE-OLD-ROOT-DIR__
   (let [root (:root OVERTONE-DIRS)]
-      (when (path-exists? (str root "/config"))
+      (when (path-exists? (mk-path root "config"))
         (println "Warning - old config directory detected. Moved to ~/.overtone-old and replaced with new, empty config.")
         (mv! root (str root "-old")))))
 

--- a/src/overtone/libs/asset.clj
+++ b/src/overtone/libs/asset.clj
@@ -98,10 +98,13 @@
         dir (file dir)]
     (ls-names dir)))
 
+(defn- remove-params [url]
+   (first (split url #"\?")))
+
 (defn asset-path
   "Given a url will return a path to a copy of the asset on the local file
   system. Will download and persist the asset if necessary."
-  ([url] (asset-path url (last (split url #"/"))))
+  ([url] (asset-path url (last (split (remove-params url) #"/"))))
   ([url name]
      (if-let [path (fetch-cached-path url name)]
        path


### PR DESCRIPTION
This fix addresses issue  #486  and allows me to use the sampled-piano on windows. 

The files end up being stored in weird places. For example sample 148530 ends up as a wav file store here:
- ~/.overtone/assets/freesound.org-apiv2-sounds-148530-download----208323509/     
PIANO_LOUD_DB5.wav  

and a json file that describes it store in another directory                                                                                                                                                             
~/.overtone/assets/freesound.org-apiv2-sounds-148530-formatjson---4716015:      
148530          

Looking at the code, I think the same weirdness happens in linux too with the current version.                                                                             