### PR TITLE
removed obsolete JVM option CMSConcurrentMTEnabled

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
   options can be kept under `:disabled`."
   {:any
    ["-Xms512m" "-Xmx1g"                 ; Minimum and maximum sizes of the heap
-    "-XX:+CMSConcurrentMTEnabled"       ; Enable multi-threaded concurrent gc work (ParNewGC)
     "-XX:MaxGCPauseMillis=20"           ; Specify a target of 20ms for max gc pauses
     "-XX:MaxNewSize=257m"               ; Specify the max and min size of the new
     "-XX:NewSize=256m"                  ;  generation to be small


### PR DESCRIPTION
I had to remove this option to be able to start the repl with lein.

The concurrent mark sweep (CMS) garbage collector was removed in java 14
see https://en.wikipedia.org/wiki/Concurrent_mark_sweep_collector