### PR TITLE
Cast timeout-ms/wait-time to long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Added
 
-- Added `set-fret` and `slide-string` to `overtone.synth.stringed`
-- Add an example file for the stringed synths
+- Added `set-fret` and `slide-string` to `overtone.synth.stringed` (#287)
+- Add an example file for the stringed synths (#287)
 
 ## Fixed
+
+- Fix an issue where Clojure fails to resolve the right `Thread/sleep`
+  implementation on newer JVMs
 
 ## Changed
 

--- a/src/overtone/libs/deps.clj
+++ b/src/overtone/libs/deps.clj
@@ -174,8 +174,8 @@
   ([deps] (wait-until-deps-satisfied deps 20 0.1))
   ([deps timeout] (wait-until-deps-satisfied deps timeout 0.1))
   ([deps timeout wait-time]
-     (let [timeout-ms (* 1000 timeout)
-           wait-time  (* 1000 wait-time)]
+     (let [timeout-ms (long (* 1000 timeout))
+           wait-time  (long (* 1000 wait-time))]
        (if (<= timeout-ms 0)
          (while (not (deps-satisfied? deps))
            (Thread/sleep wait-time))


### PR DESCRIPTION
Fixes an issue where Clojure fails to resolves the Thread/sleep call on newer JVMs.

Closes #497