### PR TITLE
Fix 21-arity version of clojure.lang.IFn

### DIFF
--- a/src/overtone/helpers/lib.clj
+++ b/src/overtone/helpers/lib.clj
@@ -139,13 +139,18 @@
      clojure.lang.IFn
      ~@(map (fn [n]
               (let [args (for [i (range n)] (symbol (str "arg" i)))]
-                (if (empty? args)
+                (cond
+                  (empty? args)
                   `(~'invoke [this#]
-                             (~invoke_fn this#))
+                    (~invoke_fn this#))
+                  (= 21 n)
                   `(~'invoke [this# ~@args]
-                             (~invoke_fn this# ~@args))))) (range 21))
+                    (apply ~invoke_fn this# ~@args))
+                  :else
+                  `(~'invoke [this# ~@args]
+                    (~invoke_fn this# ~@args))))) (range 22))
      (~'applyTo [this# args#]
-       (apply ~invoke_fn this# args#))))
+      (apply ~invoke_fn this# args#))))
 
 (defn- syms-to-keywords [coll]
   (map #(if (symbol? %)

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -1,7 +1,7 @@
-(ns ^{:doc    "An API for interacting with the awesome free online sample resource
-            freesound.org"
-      :author "Sam Aaron, Kevin Neaton"}
-    overtone.samples.freesound
+(ns overtone.samples.freesound
+  "An API for interacting with the awesome free online sample resource
+  freesound.org"
+  {:author "Sam Aaron, Kevin Neaton"}
   (:use [overtone.samples.freesound.url]
         [overtone.samples.freesound.search-results]
         [overtone.sc.node])

--- a/src/overtone/sc/util.clj
+++ b/src/overtone/sc/util.clj
@@ -1,7 +1,6 @@
-(ns
-    ^{:doc "Util fns useful for interacting with sc stuff (both internally and externally)"
-      :author "Sam Aaron"}
-    overtone.sc.util)
+(ns overtone.sc.util
+  "Util fns useful for interacting with sc stuff (both internally and externally)"
+  {:author "Sam Aaron"})
 
 (defn id-mapper
   "Map all elements of col which are associative and have an :id key to the

--- a/src/overtone/synth/stringed.clj
+++ b/src/overtone/synth/stringed.clj
@@ -41,13 +41,12 @@
         note-gate-pairs (apply vector (map vector note-ins gate-ins))
         env-gen-fn (if free-on-silence
                      '(fn [x] (overtone.sc.ugens/env-gen
-                              (overtone.sc.envelope/asr 0.0001 1 0.1)
-                              :gate (second x)
-                              :action overtone.sc.ugens/FREE))
+                               (overtone.sc.envelope/asr 0.0001 1 0.1)
+                               :gate (second x)
+                               :action overtone.sc.ugens/FREE))
                      '(fn [x] (overtone.sc.ugens/env-gen
-                              (overtone.sc.envelope/asr 0.0001 1 0.1)
-                              :gate (second x))))
-        ]
+                               (overtone.sc.envelope/asr 0.0001 1 0.1)
+                               :gate (second x))))]
     `(defsynth ~name
        ~(str "a stringed instrument synth with " num-strings
              " strings mixed and sent thru
@@ -92,7 +91,7 @@
              ;; distortion from fx-distortion2
              k#   (~'/ (~'* 2 ~'distort') (~'- 1 ~'distort'))
              dis# (~'/ (~'* src# (~'+ 1 k#))
-                       (~'+ 1 (~'* k# (abs src#))))
+                   (~'+ 1 (~'* k# (~'abs src#))))
              vrb# (free-verb dis# ~'rvb-mix ~'rvb-room ~'rvb-damp)
              fil# (rlpf vrb# ~'lp-freq ~'lp-rq)]
          (out ~'out-bus (pan2 (~'* ~'amp fil#) ~'pan))))))


### PR DESCRIPTION
Besides the versions with a fixed number of arguments, there is one final one that takes an array as its final argument (i.e. a Java varargs function). Take that into account so we don't run into AbstractMethod error when it gets called.

Also deals with an issue using an unquoted `abs` in the stringed instrument, and some minor namespace cleanup.