### PR TITLE
Improve how we deal with `abs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 - Added `set-fret` and `slide-string` to `overtone.synth.stringed` (#287)
 - Add an example file for the stringed synths (#287)
+- Add an alias `lin-env` for `lin`, for backwards compatibility
+- On the generated docstring for ugens that collide with Clojure built-ins, mention that you can add a final `:force-ugen` argument as a hint to treat it as a ugen
 
 ## Fixed
 
 - Fix an issue where Clojure fails to resolve the right `Thread/sleep`
-  implementation on newer JVMs
+  implementation on newer JVMs (#502)
+- Fix calling synths/instruments with 21 arguments or more (#504)
+- Fix the namespace `overtone.inst.synth` on Clojure 1.11
+- Mark `abs` as a Clojure numerical function, to make sure it is treated as a UGen when its arguments are not numerical
 
 ## Changed
 

--- a/docs/config.clj
+++ b/docs/config.clj
@@ -26,6 +26,8 @@
                     ; :debug - logs :error, :warn, :info and
                     ;          diagnostic information
 
+ :sc-path "/usr/bin/scsynth" ; Where to find the SuperCollider server executable
+
  :sc-args           ; Argument map used to boot the SuperCollider server
                     ; with the following arguments:
  {

--- a/src/overtone/config/file_store.clj
+++ b/src/overtone/config/file_store.clj
@@ -1,13 +1,11 @@
-(ns ^{:doc "Provides a simple key/value store which will automatically
-            persist to a file on disk. The file is serialized clojure
-            code which can be easily edited as text."
-      :author "Jeff Rose, Kevin Neaton"}
-  overtone.config.file-store
+(ns overtone.config.file-store
+  "Provides a simple key/value store which will automatically persist to a file on
+  disk. The file is serialized clojure code which can be easily edited as text."
+  {:author "Jeff Rose, Kevin Neaton"}
   (:use [clojure.pprint])
   (:require [overtone.helpers.file :as file-helpers])
-  (:import [java.io FileOutputStream FileInputStream])
+  (:import [java.io FileOutputStream FileInputStream]))
 
-)
 ;; This should be temporary...
 (def storage (constantly :file))
 

--- a/src/overtone/config/store.clj
+++ b/src/overtone/config/store.clj
@@ -1,7 +1,6 @@
-(ns
-  ^{:doc "Library initialization and configuration."
-     :author "Jeff Rose"}
-  overtone.config.store
+(ns overtone.config.store
+  "Library initialization and configuration."
+  {:author "Jeff Rose"}
   (:use [overtone.config.file-store]
         [overtone.helpers.string :only [capitalize]]
         [overtone.helpers.system :only [get-os system-user-name]]

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -1,9 +1,8 @@
-(ns ^{:doc "Functions to help generate and manipulate frequencies and
-    sets of related frequencies. This is the place for functions
-    representing general musical knowledge, like scales, chords,
-    intervals, etc."
-      :author "Jeff Rose, Sam Aaron & Marius Kempe"}
-  overtone.music.pitch
+(ns overtone.music.pitch
+  "Functions to help generate and manipulate frequencies and sets of related
+  frequencies. This is the place for functions representing general musical
+  knowledge, like scales, chords, intervals, etc."
+  {:author "Jeff Rose, Sam Aaron & Marius Kempe"}
   (:use [overtone.helpers old-contrib]
         [overtone.helpers.map :only [reverse-get]]
         [overtone.algo chance])

--- a/src/overtone/sc/envelope.clj
+++ b/src/overtone/sc/envelope.clj
@@ -170,6 +170,8 @@
   (with-overloaded-ugens
     (envelope [0 level level 0] [attack sustain release] curve)))
 
+(def lin-env lin) ;; support legacy code
+
 (defunk-env cutoff
   "Create a cutoff envelope description suitable for use with the env-gen ugen"
   [release 0.1 level 1 curve :linear]

--- a/src/overtone/sc/machinery/ugen/fn_gen.clj
+++ b/src/overtone/sc/machinery/ugen/fn_gen.clj
@@ -321,7 +321,7 @@
   (assoc doc-spec :doc
          (str
           (:doc doc-spec)
-          "\n\nThis ugen's name collides with the existing fn " collider ". When calling this fn within a synth definition, " collider " will be called unless the argument list suggests that this is a ugen call. " ugen-collide-ns-str  "/" (str op-name) " will therefore only be called if the arg list is a single map or at least one of the args is a ugen and the rest consist only of numbers, sequentials, keywords and other ugens. "
+          "\n\nThis ugen's name collides with the existing fn " collider ". When calling this fn within a synth definition, " collider " will be called unless the argument list suggests that this is a ugen call. " ugen-collide-ns-str  "/" (str op-name) " will therefore only be called if the arg list is a single map or at least one of the args is a ugen and the rest consist only of numbers, sequentials, keywords and other ugens. Add `:force-ugen` as a final argument to always treat it as a ugen. "
           (when (NUMERICAL-CLOJURE-FNS (str op-name))
             "Also, as this fn has been labelled as numerical, it will also be treated as a ugen if any of the args are not numbers."))))
 

--- a/src/overtone/sc/machinery/ugen/metadata/binaryopugen.clj
+++ b/src/overtone/sc/machinery/ugen/metadata/binaryopugen.clj
@@ -2,9 +2,7 @@
   (:use [overtone.helpers lib]))
 
 (def unnormalized-binaryopugen-docspecs
-
-  {
-   "+"           {:summary "Signal summing"
+  {"+"           {:summary "Signal summing"
                   :doc "Merges two signals by adding them together."}
 
    "-"           {:summary "Signal subtraction"
@@ -111,6 +109,7 @@
 
                         This should not be used for simulating a doppler
                         shift because it is discontinuous. Use hypot."}
+
    "pow"         {:summary "exponentiation"
                   :doc "Returns a to the power of b
 
@@ -186,8 +185,7 @@
                   :doc "folds input wave a to +/- b"}
 
    "wrap2"       {:summary "Bilateral wrapping"
-                  :doc "wraps input wave to +/- b"}
-   })
+                  :doc "wraps input wave to +/- b"}})
 
 (def binaryopugen-docspecs
   (into {} (map

--- a/src/overtone/sc/machinery/ugen/special_ops.clj
+++ b/src/overtone/sc/machinery/ugen/special_ops.clj
@@ -121,7 +121,7 @@
 
 ;;the following are Clojure fns that can only take numerical args
 (def NUMERICAL-CLOJURE-FNS
-  #{"+" "*" "-" "/" "<" ">" "<=" ">=" "min" "max" "mod"})
+  #{"+" "*" "-" "/" "<" ">" "<=" ">=" "min" "max" "mod" "abs"})
 
 (def REVERSE-BINARY-OPS (zipmap (vals BINARY-OPS) (keys BINARY-OPS)))
 

--- a/src/overtone/sc/ugens.clj
+++ b/src/overtone/sc/ugens.clj
@@ -1,11 +1,10 @@
-(ns ^{:doc "Namespace containing fns to generate UGens, or Unit
-    Generators. These are the functions that act as DSP nodes in the
-    synthesizer definitions used by SuperCollider.  We generate the UGen
-    functions based on hand written metadata about each ugen (ugen
-    directory). (Eventually we hope to get this information dynamically
-    from the server.)"
-      :author "Jeff Rose & Christophe McKeon"}
-  overtone.sc.ugens
+(ns overtone.sc.ugens
+  "Namespace containing fns to generate UGens, or Unit Generators. These are the
+  functions that act as DSP nodes in the synthesizer definitions used by
+  SuperCollider. We generate the UGen functions based on hand written metadata
+  about each ugen (ugen directory). (Eventually we hope to get this information
+  dynamically from the server.)"
+  {:author "Jeff Rose & Christophe McKeon"}
   (:use [overtone.sc.machinery.ugen fn-gen]))
 
 ;; Done actions are typically executed when an envelope ends, or a sample ends


### PR DESCRIPTION
Since Clojure 1.11 abs is a function in clojure, and thus clashes with the abs UGen. By marking it as a numerical function that's less of a problem. 

Also bring back lin-env as an alias for lin, and (sort of) document `:force-ugen`.