### PR TITLE
Changes for next major release, 0.13.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ target/
 /classes
 /.classpath
 .cpcache
-/bin
 /.settings
 .nrepl-port
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   instead of relying on `jack_lsp` which may not be available, especially on
   PipeWire-based systems
 - Reduce HTTP retries when downloading samples from 100 to 20
+- print `BufferInfo` as a reader conditional + map, to make it clear it's a data object
 
 # 0.12.3152 (2023-12-26 / 7bad685)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Added
 
+- Watch for MIDI device plug/unplug, so that adding a device doesn't require a
+  restart. These will also emit events: `:midi-device-connected` /
+  `:midi-device-disconnected` / `:midi-receiver-connected` /
+  `:midi-receiver-disconnected`
+
 ## Fixed
 
 - Make sure we print the correct version when booting
@@ -14,7 +19,6 @@
   instead of relying on `jack_lsp` which may not be available, especially on
   PipeWire-based systems
 - Reduce HTTP retries when downloading samples from 100 to 20
-  
 
 # 0.12.3152 (2023-12-26 / 7bad685)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 
+- New `loop-buf` UGen, for looping samples (part of sc3-plugins "extras")
 - Watch for MIDI device plug/unplug, so that adding a device doesn't require a
   restart. These will also emit events: `:midi-device-connected` /
   `:midi-device-disconnected` / `:midi-receiver-connected` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Use JNA Jack (via casa.squid.jack) to connect SuperCollider's audio output,
   instead of relying on `jack_lsp` which may not be available, especially on
   PipeWire-based systems
+- Reduce HTTP retries when downloading samples from 100 to 20
+  
 
 # 0.12.3152 (2023-12-26 / 7bad685)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## Changed
 
+- Use JNA Jack (via casa.squid.jack) to connect SuperCollider's audio output,
+  instead of relying on `jack_lsp` which may not be available, especially on
+  PipeWire-based systems
+
 # 0.12.3152 (2023-12-26 / 7bad685)
 
 This is the first version without the internal SuperCollider server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Fixed
 
+- Make sure we print the correct version when booting
+- Fix the license information in pom.xml (MIT)
+
 ## Changed
 
 # 0.12.3152 (2023-12-26 / 7bad685)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Make sure we print the correct version when booting
 - Fix the license information in pom.xml (MIT)
 - Handle a 401 response from Freesound by asking for a new token, instead of retrying
+- Allow writing buffers that are bigger than MAX-OSC-SAMPLES
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   restart. These will also emit events: `:midi-device-connected` /
   `:midi-device-disconnected` / `:midi-receiver-connected` /
   `:midi-receiver-disconnected`
+- Add `buffer-alloc-read-channel`, like `buffer-alloc-read` (instruct the SC
+  server to load a sound file), but only reads a single channel. Corresponds
+  with the `/b_allocReadChannel` OSC message.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Make sure we print the correct version when booting
 - Fix the license information in pom.xml (MIT)
+- Handle a 401 response from Freesound by asking for a new token, instead of retrying
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Fix the license information in pom.xml (MIT)
 - Handle a 401 response from Freesound by asking for a new token, instead of retrying
 - Allow writing buffers that are bigger than MAX-OSC-SAMPLES
+- Reuse param `:value` atoms when re-evaluating a `defsynth`/`definst`, so that
+  your synth settings aren't lost after a change
 
 ## Changed
 

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Open Source Initiative OSI - The MIT License:Licensing
 
 The MIT License
 
-Copyright (c) 2018 <All contributors listed in the README.md file>.
+Copyright (c) 2009-2024 <All contributors listed in the README.md file>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -37,7 +37,19 @@ collaborating with music.  It provides:
 
 ### Installation
 
-- Install the clojure-cli tools, see [Clojure guides: Getting Started](https://clojure.org/guides/getting_started)
+- Install Java, since this is a prerequisite for Clojure
+  - Quite often Java will already be installed, if `java -version` works and
+    shows you a version of 11 or higher you should be good
+  - On Linux, you should be able to use your operating system package manager,
+    for instance on Ubuntu the package will be called something like
+    `openjdk-17-jdk`
+  - On MacOS you can use Homebrew if you have it
+  - [https://adoptium.net/](Adoptium.net) has installers for most operating systems
+  
+- Install the Clojure CLI tools, see [Install Clojure](https://clojure.org/guides/install_clojure)
+  - Also install `rlwrap` if you can, without it `clojure` will work, but `clj`
+    will not, and you won't have history and line editing in your Clojure REPL
+  
 - Install [SuperCollider](https://supercollider.github.io/), preferrably through your operating system's package manager (apt, yum, pacman, homebrew, chocolatey, etc.)
   - The main package is called `supercollider` everywhere
   - If there's a package names `sc3-plugins`, then install that as well

--- a/README.md
+++ b/README.md
@@ -38,67 +38,67 @@ collaborating with music.  It provides:
 ### Installation
 
 ```sh
-    # Install the clojure-cli tools
-    # https://clojure.org/guides/getting_started
+# Install the clojure-cli tools
+# https://clojure.org/guides/getting_started
 
-    # Create a deps.edn file with a minimum
-    # {:deps {overtone/overtone {:mvn/version "0.12.3152"}}}
-    $ clojure
-    $ (use 'overtone.live)
+# Create a deps.edn file with a minimum
+# {:deps {overtone/overtone {:mvn/version "0.12.3152"}}}
+$ clojure
+$ (use 'overtone.live)
 ```
 
 ```sh
-    # Or install leiningen
-    # https://github.com/technomancy/leiningen
+# Or install leiningen
+# https://github.com/technomancy/leiningen
 
-    $ lein new insane-noises
+$ lein new insane-noises
 
-    # add the following dependencies to insane-noises/project.clj
-    # [org.clojure/clojure "1.9.0"]
-    # [overtone/overtone "0.12.3152"]
+# add the following dependencies to insane-noises/project.clj
+# [org.clojure/clojure "1.9.0"]
+# [overtone/overtone "0.12.3152"]
 
-    $ cd insane-noises
-    $ lein repl
+$ cd insane-noises
+$ lein repl
 ```
 
 ### Making sounds
 
 
 ```clj
-    ;; boot the server
-    user=> (use 'overtone.live)
+;; boot the server
+user=> (use 'overtone.live)
 
-    ;; listen to the joys of a simple sine wave
-    user=> (demo (sin-osc))
+;; listen to the joys of a simple sine wave
+user=> (demo (sin-osc))
 
-    ;; or something more interesting...
-    user=> (demo 7 (lpf (mix (saw [50 (line 100 1600 5) 101 100.5]))
-                   (lin-lin (lf-tri (line 2 20 5)) -1 1 400 4000)))
+;; or something more interesting...
+user=> (demo 7 (lpf (mix (saw [50 (line 100 1600 5) 101 100.5]))
+                    (lin-lin (lf-tri (line 2 20 5)) -1 1 400 4000)))
 ```
 
 ### Linter (clj-kondo)
+
 Run `overtone.linter/emit!` to emit clj-kondo configuration.
 
 Do **not** commit the generated files, it's a bunch of data.
 
 ### Detailed Instructions
 
-For a more detailed set of setup instructions (including details
-specific to Windows and Linux) head over to the
-[Overtone wiki installation page](https://github.com/overtone/overtone/wiki/Installing-Overtone)
+For a more detailed set of setup instructions (including details specific to
+Windows and Linux) head over to the [Overtone wiki installation
+page](https://github.com/overtone/overtone/wiki/Installing-Overtone)
 
-We maintain documentation for all aspects of the system in the
-[project wiki](https://github.com/overtone/overtone/wiki/Home), you'll
-find tutorials and examples on topics such as synthesizing new sounds
-from scratch, live-coding and generating musical scores on the fly. If
-you see anything missing, please feel free to add it yourself, or hit us
-up on the [mailing list](http://groups.google.com/group/overtone) and
-we'll sort something out.
+We maintain documentation for all aspects of the system in the [project
+wiki](https://github.com/overtone/overtone/wiki/Home), you'll find tutorials and
+examples on topics such as synthesizing new sounds from scratch, live-coding and
+generating musical scores on the fly. If you see anything missing, please feel
+free to add it yourself, or hit us up on the [mailing
+list](http://groups.google.com/group/overtone) and we'll sort something out.
 
 ## Cheat Sheet
 
-For a quick glance at all the exciting functionality Overtone puts at
-your musical fingertips check out the cheat sheet:
+For a quick glance at all the exciting functionality Overtone puts at your
+musical fingertips check out the cheat sheet:
 
 https://github.com/overtone/overtone/raw/master/docs/cheatsheet/overtone-cheat-sheet.pdf
 
@@ -113,18 +113,17 @@ A list of bands using Overtone to generate sounds:
 
 ### Mailing List
 
-We encourage you to join the
-[mailing list](http://groups.google.com/group/overtone) to see what
-other people are getting up to with Overtone. Use it to ask questions,
-show off what you've made and even meet fellow Overtoners in your area
-so you can meet up for impromptu jam sessions. All we ask is that you be
-considerate, courteous and respectful and that you share as much of your
-code as possible so we can all learn how to make crazy cool sounds
-together.
+We encourage you to join the [mailing
+list](http://groups.google.com/group/overtone) to see what other people are
+getting up to with Overtone. Use it to ask questions, show off what you've made
+and even meet fellow Overtoners in your area so you can meet up for impromptu
+jam sessions. All we ask is that you be considerate, courteous and respectful
+and that you share as much of your code as possible so we can all learn how to
+make crazy cool sounds together.
 
-### Twitter
+### Clojurians Slack
 
-Follow `@overtone` on Twitter: http://twitter.com/overtone
+You can find us in the `#overtone` channel on [Clojurians Slack](https://clojurians.net).
 
 ### Web
 
@@ -165,9 +164,9 @@ There are also the following tutorials:
 
 ### Interviews
 
-Overtone has generated quite a bit of interest. Here's a list of
-available interviews which go into further depth on the background and
-philosophy of Overtone:
+Overtone has generated quite a bit of interest. Here's a list of available
+interviews which go into further depth on the background and philosophy of
+Overtone:
 
 * http://twit.tv/show/floss-weekly/197
 * http://mostlylazy.com/2011/11/18/episode-0-0-2-sam-aaron-and-overtone-at-clojure-conj-2011/
@@ -181,7 +180,6 @@ philosophy of Overtone:
 * Piotr Jagielski‏: https://www.youtube.com/watch?v=r8YKC7Qugm8
 * Sam Aaron Live @ Arnolfini:  https://vimeo.com/46867490
 * Meta-eX Live @ Music Tech Fest: http://youtu.be/zJqH5bNcIN0?t=15m25s
-
 
 ## Source Repository
 
@@ -198,15 +196,21 @@ Overtone and its dependencies are on http://clojars.org, and the
 dependency for your `deps.edn` is:
 
 ```Clojure
-    {overtone/overtone {:mvn/version "0.12.3152"}}
+{overtone/overtone {:mvn/version "0.12.3152"}}
 ```
 
 or for your `project.clj` (Leiningen)
 
 ```Clojure
-    [overtone "0.10.6"]
+[overtone/overtone "0.12.3152"]
 ```
 
 ## Contributors
 
 See: https://github.com/overtone/overtone/graphs/contributors
+
+## License
+
+The MIT License, see [[LICENSE]].
+
+Copyright &copy; 2009-2024 Jeff Ross, Sam Aaron, and contributors.

--- a/README.md
+++ b/README.md
@@ -37,28 +37,30 @@ collaborating with music.  It provides:
 
 ### Installation
 
-```sh
-# Install the clojure-cli tools
-# https://clojure.org/guides/getting_started
+- Install the clojure-cli tools, see [Clojure guides: Getting Started](https://clojure.org/guides/getting_started)
+- Install [SuperCollider](https://supercollider.github.io/), preferrably through your operating system's package manager (apt, yum, pacman, homebrew, chocolatey, etc.)
+  - The main package is called `supercollider` everywhere
+  - If there's a package names `sc3-plugins`, then install that as well
 
-# Create a deps.edn file with a minimum
-# {:deps {overtone/overtone {:mvn/version "0.12.3152"}}}
-$ clojure
-$ (use 'overtone.live)
+At this point you should have `clojure` and `scsynth` available.
+
+```shell
+$ clojure --version
+Clojure CLI version 1.11.1.1413
+
+$ scsynth -v
+scsynth 3.13.0 (Built from  '' [na])
 ```
 
+Now you can add `overtone/overtone` as a dependency, and start a Clojure REPL.
+
 ```sh
-# Or install leiningen
-# https://github.com/technomancy/leiningen
+mkdir happy-vibes && cd happy-vibes
+echo '{:deps {overtone/overtone {:mvn/version "0.12.3152"}}}' > deps.edn
+clj
 
-$ lein new insane-noises
-
-# add the following dependencies to insane-noises/project.clj
-# [org.clojure/clojure "1.9.0"]
-# [overtone/overtone "0.12.3152"]
-
-$ cd insane-noises
-$ lein repl
+Clojure 1.11.1
+user=>
 ```
 
 ### Making sounds
@@ -67,6 +69,12 @@ $ lein repl
 ```clj
 ;; boot the server
 user=> (use 'overtone.live)
+--> Loading Overtone...
+[overtone.live] [INFO] Found SuperCollider server: /usr/bin/scsynth (PATH)
+--> Booting external SuperCollider server...
+--> Connecting to external SuperCollider server: 127.0.0.1:26325
+[scynth] SuperCollider 3 server ready.
+--> Connection established
 
 ;; listen to the joys of a simple sine wave
 user=> (demo (sin-osc))

--- a/bin/proj
+++ b/bin/proj
@@ -1,0 +1,17 @@
+#!/usr/bin/env bb
+
+(ns proj (:require [lioss.main :as lioss]))
+
+(lioss/main
+ {:license        :mit
+  :group-id       "overtone"
+  :gh-project     "overtone/overtone"
+  :org-name       "Overtone"
+  :org-url        "https://overtone.github.io/"
+  :inception-year 2009
+  :description    "Sound and music live programming environment."})
+
+
+;; Local Variables:
+;; mode:clojure
+;; End:

--- a/bin/proj
+++ b/bin/proj
@@ -1,6 +1,19 @@
 #!/usr/bin/env bb
 
-(ns proj (:require [lioss.main :as lioss]))
+(ns proj
+  (:require
+   [lioss.main :as lioss]
+   [clojure.string :as str]))
+
+(defn update-version-file [conf]
+  (let [[major minor teeny] (map parse-long (str/split (:version conf) #"\."))]
+    (spit
+     "src/overtone/version.clj"
+     (str/replace
+      (slurp "src/overtone/version.clj")
+      #"\(def OVERTONE-VERSION .*\)"
+      (pr-str
+       `(~'def ~'OVERTONE-VERSION {:major ~major :minor ~minor :patch ~teeny :snapshot false}))))))
 
 (lioss/main
  {:license        :mit
@@ -9,7 +22,11 @@
   :org-name       "Overtone"
   :org-url        "https://overtone.github.io/"
   :inception-year 2009
-  :description    "Sound and music live programming environment."})
+  :description    "Sound and music live programming environment."
+  :pre-release-hook update-version-file
+  :commands ["update-version-file"
+             {:description "Store the current version in overtone/version.clj"
+              :command update-version-file}]})
 
 
 ;; Local Variables:

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,8 @@
   org.clojure/data.json   {:mvn/version "2.5.0"}  ; Freesound
   commons-net/commons-net {:mvn/version "3.10.0"} ; Decode OSC timetag
   javax.jmdns/jmdns       {:mvn/version "3.4.1"}  ; ZeroConf support
-  clj-glob/clj-glob       {:mvn/version "1.0.0"}} ; overtone.helpers.file/{glob,ls*}
+  clj-glob/clj-glob       {:mvn/version "1.0.0"} ; overtone.helpers.file/{glob,ls*}
+  casa.squid/jack         {:mvn/version "0.2.12"}}
 
  :aliases
  {:test

--- a/docs/cheatsheet/overtone-cheat-sheet.tex
+++ b/docs/cheatsheet/overtone-cheat-sheet.tex
@@ -337,7 +337,7 @@
                  \subsection{Buffers}
                  \begin{tabularx}{\hsize}{lX}
                    Create \& Free & \cmd{buffer buffer-free buffer-alloc-read} \\
-                   Generate Buffer Data & \cmd{data->wavetable create-buffer-data}\\
+                   Generate Buffer Data & \cmd{signal->wavetable create-buffer-data}\\
                    Read \& Write To Server & \cmd{buffer-read buffer-write! buffer-write-relay! buffer-fill! buffer-set! buffer-get buffer-save buffer-data buffer-read}\\
                    Write To Filesystem & \cmd{write-wav}\\
                    Streaming In \& Out&\cmd{buffer-stream buffer-stream? buffer-stream-close buffer-cue buffer-cue? buffer-cue-pos buffer-stream-close}\\

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>overtone</groupId>
   <artifactId>overtone</artifactId>
-  <version>0.12.3152</version>
+  <version>0.12.3156</version>
   <name>overtone</name>
-  <description>Collaborative Programmable Music.</description>
+  <description>Sound and music live programming environment.</description>
   <url>https://github.com/overtone/overtone</url>
-  <inceptionYear>2019</inceptionYear>
+  <inceptionYear>2009</inceptionYear>
   <organization>
     <name>Overtone</name>
     <url>https://overtone.github.io/</url>
@@ -17,15 +17,15 @@
   </properties>
   <licenses>
     <license>
-      <name>Eclipse Public License 1.0</name>
-      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <name>The MIT License (MIT)</name>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
   <scm>
     <url>https://github.com/overtone/overtone</url>
     <connection>scm:git:git://github.com/overtone/overtone.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/overtone/overtone.git</developerConnection>
-    <tag>a7a2b10e8cfed08dfd58497b5d2a37f585b3e5f6</tag>
+    <tag>361e1e6f44042e8260b55d70098cf5c257ef9ddd</tag>
   </scm>
   <dependencies>
     <dependency>
@@ -78,7 +78,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <git-revision>a7a2b10e8cfed08dfd58497b5d2a37f585b3e5f6</git-revision>
+              <git-revision>361e1e6f44042e8260b55d70098cf5c257ef9ddd</git-revision>
             </manifestEntries>
           </archive>
         </configuration>

--- a/src/overtone/byte_spec.clj
+++ b/src/overtone/byte_spec.clj
@@ -87,7 +87,7 @@
                     (next (next specs))
                     (next (next (next specs))))
             fields (conj fields spec)]
-                                        ;(println (str "field: " spec))
+        ;; (println (str "field: " spec))
         (recur specs fields))
       {:name (str spec-name)
        :specs fields})))
@@ -145,9 +145,9 @@
 (declare spec-write)
 
 (defn- spec-write-array [spec ary]
-                                        ;(println (str "WRITE-A: [ "
-                                        ;     (if (map? spec) (:name spec) spec) " ](" (count ary) ")"))
-                                        ;(println "ary: " ary)
+  ;; (println (str "WRITE-A: [ "
+  ;;      (if (map? spec) (:name spec) spec) " ](" (count ary) ")"))
+  ;; (println "ary: " ary)
   (let [nxt-writer (cond
                      (contains? WRITERS spec) (spec WRITERS)
                      (map? spec) (partial spec-write spec)
@@ -169,20 +169,20 @@
   [spec data]
   (doseq [{:keys [fname ftype fdefault]} (:specs spec)]
     (cond
-                                        ; count of another field starting with n-
+      ;; count of another field starting with n-
       (.startsWith (name fname) "n-")
       (let [wrt (ftype WRITERS)
             c-field (get data (count-for fname))
             cnt (count c-field)]
         (wrt cnt))
 
-                                        ; an array of sub-specs
+      ;; an array of sub-specs
       (vector? ftype) (spec-write-array (first ftype) (fname data))
 
-                                        ; a single sub-spec
+      ;; a single sub-spec
       (map? ftype) (spec-write ftype (fname data))
 
-                                        ; a basic type
+      ;; a basic type
       (contains? WRITERS ftype) (spec-write-basic ftype fname (fname data) fdefault)
 
       true (throw (IllegalArgumentException.

--- a/src/overtone/examples/timing/internal_sequencer.clj
+++ b/src/overtone/examples/timing/internal_sequencer.clj
@@ -11,12 +11,12 @@
 ;; drive both the timing and to also modulate aspects of the synthesis
 ;; so that the modulations are sympathetic to the rhythms being played.
 
-
 ;; First, let's create some sequencer buffers for specifying which beat
 ;; to trigger a sample. This will be our core data structure for a basic
 ;; emulation of an 8-step sequencer. A buffer is like a Clojure vector,
 ;; except it lives on the server and may only contain floats. Buffers
 ;; are initialised to have all values be 0.0
+
 (defonce buf-0 (buffer 8))
 (defonce buf-1 (buffer 8))
 (defonce buf-2 (buffer 8))
@@ -31,6 +31,7 @@
 ;; contain a stream of the current tick count. We then have two of each
 ;; type of bus - one for a high resolution global metronome, and another
 ;; for a division of the global metronome for our beats.
+
 (defonce root-trg-bus (control-bus)) ;; global metronome pulse
 (defonce root-cnt-bus (control-bus)) ;; global metronome count
 (defonce beat-trg-bus (control-bus)) ;; beat pulse (fraction of root)

--- a/src/overtone/libs/asset.clj
+++ b/src/overtone/libs/asset.clj
@@ -20,7 +20,7 @@
   [url tmp-file]
   (println "--> Asset not cached - starting download...")
   (binding [*verbose-overtone-file-helpers* 2]
-    (download-file url tmp-file 20000 100 5000)))
+    (download-file url tmp-file 20000 20 5000)))
 
 (defn- safe-url
   "Return a version of url safe for use as a file or directory name. Removes

--- a/src/overtone/libs/counters.clj
+++ b/src/overtone/libs/counters.clj
@@ -1,7 +1,6 @@
-(ns
-    ^{:doc "Basic stateful keyword indexed integer counters"
-      :author "Jeff Rose and Sam Aaron"}
-    overtone.libs.counters)
+(ns overtone.libs.counters
+  "Basic stateful keyword indexed integer counters"
+  {:author "Jeff Rose and Sam Aaron"})
 
 (defonce counters* (atom {}))
 

--- a/src/overtone/midi.clj
+++ b/src/overtone/midi.clj
@@ -3,20 +3,14 @@
   configure midi input/output devices, route between devices, read/write control
   messages to devices, play notes, etc."
   {:author "Jeff Rose"}
+  (:require
+   [overtone.at-at :as at-at])
   (:import
    (java.awt.event MouseAdapter)
-   (java.util.concurrent FutureTask ScheduledThreadPoolExecutor TimeUnit)
+   (java.util.concurrent FutureTask)
    (java.util.regex Pattern)
-   (javax.sound.midi Sequencer Synthesizer
-                     MidiSystem MidiDevice Receiver Transmitter MidiEvent
-                     MidiMessage ShortMessage SysexMessage
-                     InvalidMidiDataException MidiUnavailableException
-                     MidiDevice$Info)
-   (javax.swing JFrame JScrollPane JList
-                DefaultListModel ListSelectionModel))
-  (:require
-   [clojure.set :refer :all]
-   [overtone.at-at :as at-at]))
+   (javax.sound.midi MidiDevice MidiDevice$Info MidiSystem Receiver Sequencer ShortMessage Synthesizer SysexMessage Transmitter)
+   (javax.swing DefaultListModel JFrame JList JScrollPane ListSelectionModel)))
 
 ;; Java MIDI returns -1 when a port can support any number of transmitters or
 ;; receivers, we use max int.

--- a/src/overtone/music/drums.clj
+++ b/src/overtone/music/drums.clj
@@ -1,23 +1,22 @@
-(ns overtone.music.drums
-  (:use [overtone.music time]))
+(ns overtone.music.drums)
 
-;* Pattern based rhythms
-; - define piano rolls of triggers and assign instruments to each channel
-;
+;; * Pattern based rhythms
+;; - define piano rolls of triggers and assign instruments to each channel
+
 ;; Using 1/4 notes
-;(def house-beat {:kick  [O _ _ _ O _ _ _ O _ _ _ O _ _ _]
-;                 :o-hat [_ _ O _ _ _ O _ _ _ O _ _ _ O _]
-;                 :clap  [_ _ _ _ O _ _ _ _ _ _ _ O _ _ _]})
-;
-;(make-beat house-beat {:base "kick.wav"
-;                       :o-hat "hat.wav"
-;                       :clap "clap.wav"})
-;
-;* Archaeopteryx style rhythm queue, so you can push no rhythms on to start playing, but then pop off to go back to where you were before.
-;
-;* Keep a ref var pointing to the current rhythm function(s)
-;-- returns true if it should play on the next beat?
-;-- modify the ref and you get a new beat on the fly
+;; (def house-beat {:kick  [O _ _ _ O _ _ _ O _ _ _ O _ _ _]
+;;                  :o-hat [_ _ O _ _ _ O _ _ _ O _ _ _ O _]
+;;                  :clap  [_ _ _ _ O _ _ _ _ _ _ _ O _ _ _]})
+
+;; (make-beat house-beat {:base "kick.wav"
+;;                        :o-hat "hat.wav"
+;;                        :clap "clap.wav"})
+
+;; * Archaeopteryx style rhythm queue, so you can push no rhythms on to start playing, but then pop off to go back to where you were before.
+
+;; * Keep a ref var pointing to the current rhythm function(s)
+;; -- returns true if it should play on the next beat?
+;; -- modify the ref and you get a new beat on the fly
 
 (defonce *drums (ref []))
 (defonce *drum-count (ref 0))

--- a/src/overtone/music/time.clj
+++ b/src/overtone/music/time.clj
@@ -119,7 +119,7 @@
    function to not call itself, or use (stop)."
   {:arglists '([ms-time f args* argseq])
    :arglists-modified? true}
-  [#^clojure.lang.IFn ms-time f & args]
+  [ms-time ^clojure.lang.IFn f & args]
   (let [delay-time (- ms-time *apply-ahead* (now))]
     (if (<= delay-time 0)
       (after-delay 0 #(apply f (#'clojure.core/spread args)))
@@ -156,7 +156,7 @@
    function to not call itself, or use (stop)."
   {:arglists '([ms-time f args* argseq])
    :arglists-modified? true}
-  [#^clojure.lang.IFn ms-time f & args]
+  [ms-time ^clojure.lang.IFn f & args]
   (let [delay-time (- ms-time (now))]
     (if (<= delay-time 0)
       (after-delay 0 #(apply f (#'clojure.core/spread args)))

--- a/src/overtone/music/time.clj
+++ b/src/overtone/music/time.clj
@@ -1,14 +1,15 @@
-(ns
-    ^{:doc "Functions to help manage and structure computation in time."
-      :author "Jeff Rose and Sam Aaron"}
-  overtone.music.time
-  (:use [overtone.libs event]
-        [overtone.helpers lib])
-  (:require [overtone.at-at :as at-at]
-            [overtone.sc.protocols :as protocols]))
+(ns overtone.music.time
+  "Functions to help manage and structure computation in time.
 
-;;Scheduled thread pool (created by at-at) which is to be used by default for
-;;all scheduled musical functions (players).
+  Mostly consists of convenience functions around at-at"
+  {:author "Jeff Rose and Sam Aaron"}
+  (:require
+   [overtone.at-at :as at-at]
+   [overtone.libs.event :as event]
+   [overtone.sc.protocols :as protocols]))
+
+;; Scheduled thread pool (created by at-at) which is to be used by default for
+;; all scheduled musical functions (players).
 (defonce player-pool (at-at/mk-pool))
 
 (defn now
@@ -21,7 +22,7 @@
   defaults to the player-pool."
   ([ms-delay fun] (after-delay ms-delay fun "Overtone delayed fn"))
   ([ms-delay fun description]
-     (at-at/at (+ (now) ms-delay) fun player-pool :desc description)))
+   (at-at/at (+ (now) ms-delay) fun player-pool :desc description)))
 
 (defn periodic
   "Calls fun every ms-period, and takes an optional initial-delay for
@@ -29,11 +30,11 @@
   ([ms-period fun] (periodic ms-period fun 0))
   ([ms-period fun initial-delay] (periodic ms-period fun initial-delay "Overtone periodic fn"))
   ([ms-period fun initial-delay description]
-     (at-at/every ms-period
-                  fun
-                  player-pool
-                  :initial-delay initial-delay
-                  :desc description)))
+   (at-at/every ms-period
+                fun
+                player-pool
+                :initial-delay initial-delay
+                :desc description)))
 
 (defn interspaced
   "Calls fun repeatedly with an interspacing of ms-period, i.e. the next
@@ -43,18 +44,19 @@
   ([ms-period fun] (interspaced ms-period fun 0))
   ([ms-period fun initial-delay] (interspaced ms-period fun initial-delay "Overtone interspaced fn"))
   ([ms-period fun initial-delay description]
-     (at-at/interspaced ms-period
-                        fun
-                        player-pool
-                        :initial-delay initial-delay
-                        :desc description)))
+   (at-at/interspaced ms-period
+                      fun
+                      player-pool
+                      :initial-delay initial-delay
+                      :desc description)))
 
-;;Ensure all scheduled player fns are stopped when Overtone is reset
-;;(typically triggered by a call to stop)
-(on-sync-event :reset
-               (fn [event-info] (at-at/stop-and-reset-pool! player-pool
-                                                           :strategy :kill))
-               ::player-reset)
+;; Ensure all scheduled player fns are stopped when Overtone is reset
+;; (typically triggered by a call to stop)
+(event/on-sync-event
+ :reset
+ (fn [event-info]
+   (at-at/stop-and-reset-pool! player-pool :strategy :kill))
+ ::player-reset)
 
 (defn stop-player
   "Stop scheduled fn gracefully if it hasn't already executed."
@@ -79,7 +81,7 @@
   300)
 
 (defn apply-by
-  "Ahead-of-schedule function appliction. Works identically to
+  "Ahead-of-schedule function application. Works identically to
    apply, except that it takes an additional initial argument:
    ms-time. If ms-time is in the future, function application is delayed
    until *apply-ahead* ms before that time, if ms-time is in the past

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -117,7 +117,16 @@
                (when (not @*access-token*)
                  (authorization-instructions))
                (str "Bearer " @*access-token*))]
-     ~b))
+     (let [do-request# #(do ~b)]
+       (try
+         (do-request#)
+         (catch clojure.lang.ExceptionInfo e#
+           (if (= 401 (:response-code (ex-data e#)))
+             (do
+               (println "Freesound responded with 401 Unauthorized, your token has likely expired.")
+               (reset! *access-token* nil)
+               (do-request#))
+             (throw e#)))))))
 
 ;; ## Sound Info
 (defn- info-url

--- a/src/overtone/sc/buffer.clj
+++ b/src/overtone/sc/buffer.clj
@@ -87,25 +87,11 @@
                    "This can be configured in overtone config under :sc-args {:max-buffers 2^x}.")))))
 
 (defmethod clojure.pprint/simple-dispatch BufferInfo [b]
-  (println
-   (format "#<buffer-info: %fs %s %d>"
-           (:duration b)
-           (cond
-             (= 1 (:n-channels b)) "mono"
-             (= 2 (:n-channels b)) "stereo"
-             :else                 (str (:n-channels b) " channels"))
-           (:id b))))
+  (print "#overtone/BufferInfo ")
+  (clojure.pprint/pprint (into {} b)))
 
 (defmethod print-method BufferInfo [b ^java.io.Writer w]
-  (.write w (format "#<buffer-info: %fs %s %d>"
-                    (:duration b)
-                    (cond
-                      (= 1 (:n-channels b)) "mono"
-                      (= 2 (:n-channels b)) "stereo"
-                      :else                 (str (:n-channels b) " channels"))
-                    (:id b))))
-
-
+  (.write w (str "#overtone/BufferInfo " (pr-str (into {} b)))))
 
 (defn buffer-info
   "Fetch the information for buffer associated with buf-id (either an

--- a/src/overtone/sc/machinery/synthdef.clj
+++ b/src/overtone/sc/machinery/synthdef.clj
@@ -415,20 +415,20 @@
   [pnames ugens ug]
   (assoc ug :inputs
          (map
-           (fn [{:keys [src index] :as input}]
-             (if src
-               (let [u-in (nth ugens src)]
-                 (if (= "Control" (:name u-in))
-                   (nth pnames index)
-                   (:sname (nth ugens src))))
-               input))
-           (:inputs ug))))
+          (fn [{:keys [src index] :as input}]
+            (if src
+              (let [u-in (nth ugens src)]
+                (if (= "Control" (:name u-in))
+                  (nth pnames index)
+                  (:sname (nth ugens src))))
+              input))
+          (:inputs ug))))
 
-; In order to do this correctly is a big project because you also have to
-; reverse the process of the various ugen modes.  For example, you need
-; to recognize the ugens that have array arguments which will be
-; appended, and then you need to gather up the inputs and place them into
-; an array at the correct argument location.
+;; In order to do this correctly is a big project because you also have to
+;; reverse the process of the various ugen modes.  For example, you need
+;; to recognize the ugens that have array arguments which will be
+;; appended, and then you need to gather up the inputs and place them into
+;; an array at the correct argument location.
 (defn synthdef-decompile
   "Decompile a parsed SuperCollider synth definition back into clojure
   code that could be used to generate an identical synth.
@@ -447,10 +447,10 @@
         ugens (map (partial reverse-ugen-inputs pnames ugens) ugens)
         ugens (filter #(not= "Control" (:name %)) ugens)
         ugen-forms (map vector
-                     (map :sname ugens)
-                     (map ugen-form ugens))]
-      (print (format "(defsynth %s %s\n  (let [" sname param-vec))
-      (println (ffirst ugen-forms) (second (first ugen-forms)))
-      (doseq [[uname uform] (drop 1 ugen-forms)]
-        (println "       " uname uform))
-      (println (str "       ]\n   " (first (last ugen-forms)) ")"))))
+                        (map :sname ugens)
+                        (map ugen-form ugens))]
+    (print (format "(defsynth %s %s\n  (let [" sname param-vec))
+    (println (ffirst ugen-forms) (second (first ugen-forms)))
+    (doseq [[uname uform] (drop 1 ugen-forms)]
+      (println "       " uname uform))
+    (println (str "       ]\n   " (first (last ugen-forms)) ")"))))

--- a/src/overtone/sc/machinery/ugen/defaults.clj
+++ b/src/overtone/sc/machinery/ugen/defaults.clj
@@ -1,6 +1,6 @@
-(ns ^{:doc "Default vals and fns required  to manipulate ugens."
-      :author "Jeff Rose"}
-  overtone.sc.machinery.ugen.defaults
+(ns overtone.sc.machinery.ugen.defaults
+  "Default vals and fns required  to manipulate ugens."
+  {:author "Jeff Rose"}
   (:use [overtone.helpers lib]))
 
 ;; Outputs have a specified calculation rate

--- a/src/overtone/sc/machinery/ugen/metadata/extras/loopbuf.clj
+++ b/src/overtone/sc/machinery/ugen/metadata/extras/loopbuf.clj
@@ -2,10 +2,10 @@
   (:use [overtone.sc.machinery.ugen common check]))
 
 (def specs
-  [
-   {:name "LoopBuf"
+  [{:name "LoopBuf"
     :summary "Sample looping oscillator"
     :args [{:name "n-channels"
+            :mode :num-outs
             :doc "number of channels that the buffer will be.  this must
                   be a fixed integer. The architecture of the synth
                   design cannot change after it is compiled.  warning:

--- a/src/overtone/sc/machinery/ugen/specs.clj
+++ b/src/overtone/sc/machinery/ugen/specs.clj
@@ -15,22 +15,23 @@
     io machine-listening misc osc beq-suite chaos control demand
     ff-osc fft info noise pan trig line input filter random
 
-    extras.mda
-    extras.stk
-    extras.glitch
+    extras.ay
+    extras.bat
+    extras.bbcut2u
+    extras.berlach
     extras.bhob
     extras.blackrain
     extras.distortion
+    extras.dwg
+    extras.glitch
+    extras.loopbuf
+    extras.mda
+    extras.membrane
     extras.sl
-    extras.ay
-    extras.bbcut2u
-    extras.bat
+    extras.stk
+    extras.tju
     extras.vbap
     extras.vosim
-    extras.berlach
-    extras.membrane
-    extras.tju
-    extras.dwg
     ])
 
 (defn- spec-arg-names

--- a/src/overtone/sc/node.clj
+++ b/src/overtone/sc/node.clj
@@ -835,7 +835,6 @@
   protocols/IKillable
   {:kill* group-deep-clear*})
 
-
 (extend java.lang.Long
   ISynthGroup
   {:group-prepend-node group-prepend-node*
@@ -849,37 +848,40 @@
 (defn node-tree
   "Returns a data representation of the synth node tree starting at
   the root group."
-  ([] (node-tree (:root-group @foundation-groups*)))
+  ([]
+   (node-tree (:root-group @foundation-groups*)))
   ([root]
-     (ensure-connected!)
-     (group-node-tree (to-sc-id root))))
+   (ensure-connected!)
+   (group-node-tree (to-sc-id root))))
 
 (defn node-tree-zipper
   "Returns a zipper representing the tree of the specified node or
   defaults to the current node tree"
-  ([] (node-tree-zipper (:root-group @foundation-groups*)))
+  ([]
+   (node-tree-zipper (:root-group @foundation-groups*)))
   ([root]
-     (zip/zipper map? :children #(assoc %1 :children %2) (group-node-tree root))))
+   (zip/zipper map? :children #(assoc %1 :children %2) (group-node-tree root))))
 
 (defn node-tree-seq
-  "Returns a lazy seq of a depth-first traversal of the tree of the
-  specified node defaulting to the current node tree"
+  "Returns a lazy seq of a depth-first traversal of the tree of the specified node
+  defaulting to the current node tree"
   ([] (node-tree-seq (:root-group @foundation-groups*)))
   ([root] (zipper-seq (node-tree-zipper root))))
 
 (defn node-tree-matching-synth-ids
-  "Returns a seq of synth ids in the node tree with specific
-  root (defaulting to the entire node tree) that match regexp or
-  strign."
-  ([re-or-str] (node-tree-matching-synth-ids re-or-str (:root-group @foundation-groups*)))
+  "Returns a seq of synth ids in the node tree with specific root (defaulting to
+  the entire node tree) that match regexp or string."
+  ([re-or-str]
+   (node-tree-matching-synth-ids re-or-str (:root-group @foundation-groups*)))
   ([re-or-str root]
-     (let [matcher-fn (if (string? re-or-str)
-                        =
-                        re-matches)]
-       (map :id
-            (filter #(and (:name %)
-                          (matcher-fn re-or-str (:name %)))
-                    (node-tree-seq root))))))
+   (let [matcher-fn (if (string? re-or-str)
+                      =
+                      re-matches)]
+     (map :id
+          (filter #(and (:name %)
+                        (matcher-fn re-or-str (:name %)))
+                  (node-tree-seq root))))))
+
 (defn pp-node-tree
   "Pretty print the node tree to *out*"
   ([] (pp-node-tree (:root-group @foundation-groups*)))

--- a/src/overtone/sc/synth.clj
+++ b/src/overtone/sc/synth.clj
@@ -1,10 +1,9 @@
-(ns
-    ^{:doc "The ugen functions create a data structure representing a synthesizer
-         graph that can be executed on the synthesis server.  This is the logic
-         to \"compile\" these clojure data structures into a form that can be
-         serialized by the byte-spec defined in synthdef.clj."
-      :author "Jeff Rose"}
-    overtone.sc.synth
+(ns overtone.sc.synth
+  "The ugen functions create a data structure representing a synthesizer graph
+  that can be executed on the synthesis server. This is the logic to \"compile\"
+  these clojure data structures into a form that can be serialized by the
+  byte-spec defined in synthdef.clj."
+  {:author "Jeff Rose"}
   (:use
    [clojure.walk :as walk]
    [overtone.helpers lib old-contrib synth]
@@ -16,11 +15,11 @@
    [overtone.helpers seq]
    [clojure.pprint]
    [overtone.helpers.string :only [hash-shorten]])
-
-  (:require [overtone.config.log]
-            [clojure.set :as set]
-            [overtone.sc.cgens.env :refer [hold]]
-            [overtone.sc.protocols :as protocols]))
+  (:require
+   [overtone.config.log]
+   [clojure.set :as set]
+   [overtone.sc.cgens.env :refer [hold]]
+   [overtone.sc.protocols :as protocols]))
 
 (declare synth-player)
 

--- a/src/overtone/studio/inst.clj
+++ b/src/overtone/studio/inst.clj
@@ -152,7 +152,8 @@
 (defmacro inst
   [sname & args]
   (ensure-connected!)
-  `(let [[sname# params# ugens# constants# n-chans# inst-bus#] (pre-inst ~sname ~@args)
+  `(let [full-name# '~(symbol (str *ns*) (str sname))
+         [sname# params# ugens# constants# n-chans# inst-bus#] (pre-inst ~sname ~@args)
          new-inst# (get (:instruments @studio*) sname#)
          container-group# (or (:group new-inst#)
                               (with-server-sync
@@ -178,7 +179,7 @@
                                     :in-bus inst-bus#))
          sdef#      (synthdef sname# params# ugens# constants#)
          arg-names# (map :name params#)
-         params-with-vals# (map #(assoc % :value (atom (:default %))) params#)
+         params-with-vals# (map #(assoc % :value (control-proxy-value-atom full-name# %)) params#)
          fx-chain#  []
          volume#    (atom DEFAULT-VOLUME)
          pan#       (atom DEFAULT-PAN)

--- a/src/overtone/studio/inst.clj
+++ b/src/overtone/studio/inst.clj
@@ -187,8 +187,7 @@
                              container-group# instance-group# fx-group#
                              imixer# inst-bus# fx-chain#
                              volume# pan#
-                             n-chans#
-                             )
+                             n-chans#)
                       {:overtone.helpers.lib/to-string #(str (name (:type %)) ":" (:name %))})]
      (load-synthdef sdef#)
      (add-instrument inst#)

--- a/src/overtone/version.clj
+++ b/src/overtone/version.clj
@@ -1,9 +1,6 @@
 (ns overtone.version)
 
-(def OVERTONE-VERSION {:major 0
-                       :minor 10
-                       :patch 6
-                       :snapshot false})
+(def OVERTONE-VERSION {:major 0, :minor 12, :patch 3156, :snapshot false})
 
 (def OVERTONE-VERSION-STR
   (let [version OVERTONE-VERSION]


### PR DESCRIPTION
See CHANGELOG

## Added

- New `loop-buf` UGen, for looping samples (part of sc3-plugins "extras")
- Watch for MIDI device plug/unplug, so that adding a device doesn't require a
  restart. These will also emit events: `:midi-device-connected` /
  `:midi-device-disconnected` / `:midi-receiver-connected` /
  `:midi-receiver-disconnected`
- Add `buffer-alloc-read-channel`, like `buffer-alloc-read` (instruct the SC
  server to load a sound file), but only reads a single channel. Corresponds
  with the `/b_allocReadChannel` OSC message.

## Fixed

- Make sure we print the correct version when booting
- Fix the license information in pom.xml (MIT)
- Handle a 401 response from Freesound by asking for a new token, instead of retrying
- Allow writing buffers that are bigger than MAX-OSC-SAMPLES
- Reuse param `:value` atoms when re-evaluating a `defsynth`/`definst`, so that
  your synth settings aren't lost after a change

## Changed

- Use JNA Jack (via casa.squid.jack) to connect SuperCollider's audio output,
  instead of relying on `jack_lsp` which may not be available, especially on
  PipeWire-based systems
- Reduce HTTP retries when downloading samples from 100 to 20
- print `BufferInfo` as a reader conditional + map, to make it clear it's a data object
