### PR TITLE
Fix foo and foo-timed example

### DIFF
--- a/src/overtone/examples/getting_started/basic.clj
+++ b/src/overtone/examples/getting_started/basic.clj
@@ -17,7 +17,7 @@
 (defn foo-pause
   []
   (dotimes [i 10]
-    (foo (* i 220) 1)
+    (foo (* (+ i 1) 220) 1)
     (Thread/sleep 300)))
 
 ;;(foo-pause)
@@ -32,7 +32,7 @@
   (let [n (now)]
     (dotimes [i 10]
       (at (+ n (* i 300))
-          (foo (* i 220) 1)))))
+          (foo (* (+ i 1) 220) 1)))))
 
 ;;(foo-timed)
 


### PR DESCRIPTION
- The first iteration of the do loop gives a frequency of 0
- The first iteration is now at 220 hz instead