### PR TITLE
Allow free-self to take audio-rate signals (#515)

### DIFF
--- a/src/overtone/sc/machinery/ugen/specs.clj
+++ b/src/overtone/sc/machinery/ugen/specs.clj
@@ -192,6 +192,9 @@
                  ;; Special case Pitch ugen which may have ar ugens plugged into it
                  (and (= "Pitch" (:name ugen))
                       (= :ar (:rate-name bad-input)))
+                 ;; Special case FreeSelf ugen which may have ar ugens plugged into it
+                 (and (= "FreeSelf" (:name ugen))
+                      (= :ar (:rate-name bad-input)))
 
                  ;; Special case LocalBuf which may have kr ugens plugged in
                  ;; but further modifications aren't honoured


### PR DESCRIPTION
This fixes #515.
```clj
(comment
  (o/connect-external-server)

  (o/defsynth rev-perc []
    (let [sig (-> (o/sin-osc 200)
                  (o/pan2:ar)
                  (* 0.2 (o/env-gen (o/env-perc)))
                  (o/free-verb 0.5 3))]
      (o/free-self (* (o/detect-silence (+ sig (o/impulse 0)))))
      (o/out 0 sig)))

  (def node (rev-perc))
  ;; after a while
  (println node) ;; #<synth-node[destroyed]: external.dev/rev-perc 107>  
)
  ```