### PR TITLE
Close #337: open dialog box for Freesound auth

### DIFF
--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -125,9 +125,9 @@
     (.addActionListener
       button (proxy [ActionListener] []
                (actionPerformed [event]
+                 ;; using .dispose may close the VM
+                 (.setVisible frame false)
                  (let [pw (String/valueOf (.getPassword password-field))]
-                   ;; using .dispose may close the VM
-                   (.setVisible frame false)
                    (out-fn pw)))))
     (.setVisible frame true)
     (fn [] (.dispose frame))))

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -126,7 +126,8 @@
       button (proxy [ActionListener] []
                (actionPerformed [event]
                  (let [pw (String/valueOf (.getPassword password-field))]
-                   (.dispose frame)
+                   ;; using .dispose may close the VM
+                   (.setVisible frame false)
                    (out-fn pw)))))
     (.setVisible frame true)
     (fn [] (.dispose frame))))


### PR DESCRIPTION
Close #337 

This adds an additional dialog box in case stdin doesn't work for Freesound auth.

I have no idea if the stdin flow still works with these changes since I've never successfully got it to work. You can test it by removing the `~/.overtone/user-store.edn` file and calling `((requiring-resolve 'overtone.samples.freesound/authorization-instructions))`.

<img width="199" alt="Screenshot 2024-10-12 at 5 55 06 PM" src="https://github.com/user-attachments/assets/4aef67f2-f5b8-4c1b-b1ff-983fd5a8ce7a">
