### PR TITLE
Close #528: fix octave-note, detect similar issues

### DIFF
--- a/src/overtone/helpers/gui.clj
+++ b/src/overtone/helpers/gui.clj
@@ -1,0 +1,11 @@
+(ns overtone.helpers.gui
+  (:import java.awt.event.ActionListener))
+
+(set! *warn-on-reflection* true)
+
+;; note that proxy creates a public var that could be interned
+;; into the api namespaces, so it's safer to put this helper here
+(defn action-listener ^ActionListener [->event]
+  (proxy [ActionListener] []
+    (actionPerformed [event]
+      (->event event))))

--- a/src/overtone/helpers/ns.clj
+++ b/src/overtone/helpers/ns.clj
@@ -1,5 +1,7 @@
 (ns overtone.helpers.ns)
 
+(set! *warn-on-reflection* true)
+
 (defn immigrate
   "Create a public var in this namespace for each public var in the
   namespaces named by ns-names. The created vars have the same name, value
@@ -8,9 +10,22 @@
   [& ns-names]
   (doseq [ns ns-names]
     (doseq [[sym ^clojure.lang.Var var] (ns-publics ns)]
+      (when-some [^clojure.lang.Var prev (resolve sym)]
+        (when-not (var? prev)
+          (throw (Exception. (str "Overriding non-var " prev " in " (ns-name *ns*)))))
+        (let [prev-ns (-> prev meta :orig-ns)]
+          (when-not (= prev-ns ns)
+            (println (str "WARNING: replacing " sym " in " (ns-name *ns*)
+                          " with " (symbol (name ns) (name sym)) 
+                          ", previously "
+                          (if prev-ns
+                            (symbol (name prev-ns) (name sym))
+                            (str " an unknown var "
+                                 (when (.isBound prev)
+                                   (str " with binding " @prev)))))))))
       (let [sym (with-meta sym (assoc (meta var) :orig-ns ns))]
-        (if (.isBound var)
-          (intern *ns* sym (if (fn? (var-get var))
-                             var
-                             (var-get var)))
-          (intern *ns* sym))))))
+        (when-not (.isBound var)
+          (throw (Exception. (str var " not bound!"))))
+        (intern *ns* sym (if (fn? (var-get var))
+                           var
+                           (var-get var)))))))

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -19,8 +19,9 @@
   (:import
    (javax.swing JFrame JPanel JButton JOptionPane WindowConstants
                 JPasswordField)
-   java.awt.GraphicsEnvironment
-   ))
+   java.awt.GraphicsEnvironment))
+
+(set! *warn-on-reflection* true)
 
 (def ^:dynamic *client-id* "ea6297be42e9de76d47c")
 (def ^:dynamic *api-key* "32da10a118819877ec041752680588c62684c0b2")

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -11,6 +11,7 @@
    [overtone.sc.node :refer :all]
    [overtone.config.store :as config]
    [overtone.helpers.file :refer [*authorization-header* file-extension]]
+   [overtone.helpers.gui :as gui]
    [overtone.helpers.lib :refer [defrecord-ifn]]
    [overtone.libs.asset :as asset]
    [overtone.sc.buffer :as buffer]
@@ -19,7 +20,7 @@
    (javax.swing JFrame JPanel JButton JOptionPane WindowConstants
                 JPasswordField)
    java.awt.GraphicsEnvironment
-   java.awt.event.ActionListener))
+   ))
 
 (def ^:dynamic *client-id* "ea6297be42e9de76d47c")
 (def ^:dynamic *api-key* "32da10a118819877ec041752680588c62684c0b2")
@@ -123,8 +124,8 @@
                 ;; EXIT_ON_CLOSE both risk closing the VM
                 (.setDefaultCloseOperation WindowConstants/HIDE_ON_CLOSE))]
     (.addActionListener
-      button (proxy [ActionListener] []
-               (actionPerformed [event]
+      button (gui/action-listener
+               (fn [_event]
                  ;; using .dispose may close the VM
                  (.setVisible frame false)
                  (let [pw (String/valueOf (.getPassword password-field))]

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -72,7 +72,7 @@
 (defn rest? [o]
   (#{:_ :rest} o))
 
-(defn octave-note [e octave note]
+(defn- octave-note [e octave note]
   (* (+ octave
         (/ (+ note (eget e :gtranspose))
            (eget e :steps-per-octave)))


### PR DESCRIPTION
octave-note was being interned twice from different namespaces into the api namespaces. This fixes that particular problem, and adds checks to detect similar regressions in the future.