### PR TITLE
Don't start SC during compilation

### DIFF
--- a/src/overtone/libs/boot_msg.clj
+++ b/src/overtone/libs/boot_msg.clj
@@ -1,3 +1,5 @@
 (ns overtone.libs.boot-msg)
 
-(println "--> Loading Overtone...")
+(if *compile-files*
+  (println "--> Compiling Overtone...")
+  (println "--> Loading Overtone..."))

--- a/src/overtone/live.clj
+++ b/src/overtone/live.clj
@@ -4,6 +4,8 @@
 
 (overtone.api/immigrate-overtone-api)
 
-(defonce __AUTO-BOOT__
-  (when (overtone.sc.server/server-disconnected?)
-    (overtone.studio.mixer/boot-server-and-mixer)))
+(if *compile-files*
+  (println "--> (use 'overtone.live :reload) or restart JVM to use SuperCollider after compilation")
+  (defonce __AUTO-BOOT__
+    (when (overtone.sc.server/server-disconnected?)
+      (overtone.studio.mixer/boot-server-and-mixer))))


### PR DESCRIPTION
I was curious if AOT compilation works after reading https://github.com/overtone/overtone/issues/481, and it does. This makes compilation a little more flexible so it can be performed without SC booting. I didn't test removing SC altogether so I'm not sure if compilation requires SC to be accessible (but it sounds useful if it doesn't).

This can be tested by creating a `classes` directory at the root of this repo:
```clojure
  user=> (compile 'overtone.live)
  --> Compiling Overtone...
  --> (use 'overtone.live :reload) or restart JVM to use SuperCollider after compilation
  overtone.live
  user=> (use 'overtone.live) ;; no effect
  nil
  user=> (use 'overtone.live :reload) ;; triggers __AUTO-BOOT__
  --> Booting external SuperCollider server...
```