### PR TITLE
Pattern library and other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@
   (`*current-pool*`)
 - `:sc-path` in `~/.overtone/config.clj` can now be a vector instead of a
   string, for passing additional arguments
+- `grunge-bass` : make the amp parameter do something
 
 ## Changed
+
+- Changed the implementation of the sample player to a more basic version based
+  on `play-buf`, since the old version caused clicks at the end of the sample.
+  This does mean currently looping is broken.
 
 # 0.14.3199 (2024-05-19 / 5d1c1ed)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## Fixed
 
+- Pattern library: make patterns more easily redefinable while maintaining the
+  same relative position, for smoother live updates
+- Accept `:-` as a rest note, in addition to `:_` and `:rest`
+- Recognize samples in the pattern player, so things like `:amp` work
+- Metronome: also accept `:start` and `:bar-start`, instead of just `:bpm`
+- Allow the default `at-at` threadpool to be overridden by a dynvar
+  (`*current-pool*`)
+- `:sc-path` in `~/.overtone/config.clj` can now be a vector instead of a
+  string, for passing additional arguments
+
 ## Changed
 
 # 0.14.3199 (2024-05-19 / 5d1c1ed)

--- a/src/overtone/examples/compositions/funk.clj
+++ b/src/overtone/examples/compositions/funk.clj
@@ -1,8 +1,8 @@
 (ns overtone.examples.compositions.funk
-    "This example creates a simple drum and bass pattern, based off of
-    the James Brown classic 'Licking Stick', with Bootsy Collins on bass,
-    and John Jab'o Starks on drums"
-    (:use [overtone.live]))
+  "This example creates a simple drum and bass pattern, based off of
+  the James Brown classic 'Licking Stick', with Bootsy Collins on bass,
+  and John Jab'o Starks on drums"
+  (:use [overtone.live]))
 
 ; model a plucked string, we'll use this for our bass
 (definst string [note 60 amp 1.0 dur 0.5 decay 30 coef 0.3 gate 1]
@@ -22,13 +22,12 @@
 (def close-hihat (sample (freesound-path 802)))
 (def open-hihat (sample (freesound-path 26657)))
 
-
 (defn subdivide
-    "subdivide two time intervals by 4, and return the time interval
+  "subdivide two time intervals by 4, and return the time interval
     at position. this is a cheap hack to schedule 16th notes without
     defining the whole pattern with the metronome firing every 16th note."
-    [a b position]
-    (+ a (* position (/ (- b a) 4) )))
+  [a b position]
+  (+ a (* position (/ (- b a) 4) )))
 
 (defn drums [nome]
     (let [beat (nome)]

--- a/src/overtone/inst/synth.clj
+++ b/src/overtone/inst/synth.clj
@@ -206,8 +206,7 @@
         env  (env-gen (adsr 0.001 0.2 0.9 0.25) gate amp :action FREE)]
     (* snd env)))
 
-(definst grunge-bass
-  [note 48 amp 0.5 dur 0.1 a 0.01 d 0.01 s 0.4 r 0.01]
+(definst grunge-bass [note 48 amp 1 dur 0.1 a 0.01 d 0.01 s 0.4 r 0.01]
   (let [freq    (midicps note)
         env     (env-gen (adsr a d s r) (line:kr 1 0 (+ a d dur r 0.1))
                          :action FREE)
@@ -218,7 +217,7 @@
         meat    (ring4 filt sub)
         sliced  (rlpf meat (* 2 freq) 0.1)
         bounced (free-verb sliced 0.8 0.9 0.2)]
-    (* env bounced)))
+    (* amp env bounced)))
 
 (definst vintage-bass
   [note 40 velocity 80 t 0.6 amp 1 gate 1]

--- a/src/overtone/music/rhythm.clj
+++ b/src/overtone/music/rhythm.clj
@@ -48,7 +48,6 @@
 ;;   ([b] (* (bar 1) (first @*signature) b)))
 
 (deftype Metronome [start bar-start bpm bpb]
-
   IMetronome
   (metro-start [metro] @start)
   (metro-start [metro start-beat]
@@ -139,7 +138,11 @@
       (number? arg) (metro-beat this arg)
       (= :bpm arg) (metro-bpm this) ;; (bpm this) fails.
       :else (throw (Exception. (str "Unsupported metronome arg: " arg)))))
-  (invoke [this _ new-bpm] (metro-bpm this new-bpm)))
+  (invoke [this kw new-val]
+    (case kw
+      :bpm (metro-bpm this new-val)
+      :start (metro-start this new-val)
+      :bar-start (metro-bar-start this new-val))))
 
 (defn metronome
   "A metronome is a beat management function.  Tell it what BPM you want,
@@ -155,7 +158,8 @@
   (m)          ; => <next beat number>
   (m 200)      ; => <timestamp of beat 200>
   (m :bpm)     ; => return the current bpm val
-  (m :bpm 140) ; => set bpm to 140"
+  (m :bpm 140) ; => set bpm to 140
+  (m :start 80) ; => set start beat to 80"
   [bpm]
   (let [start (ref (now))
         bar-start (ref @start)

--- a/src/overtone/protocols.clj
+++ b/src/overtone/protocols.clj
@@ -1,43 +1,43 @@
 (ns overtone.protocols)
 
-; This is a holding ground for working on protocols...
+;; This is a holding ground for working on protocols...
 
-; One goal of defining protocols is to clearly delineate various groups of functionality
-; so we can improve the composability of the Overtone building blocks.  Our current synths
-; and instruments grew out of a desire to make things easy to use, but we need to refactor them
-; split-up unneccessarily bound aspects of functionality, and then create new "easy" APIs using
-; these refactored elements.
+;; One goal of defining protocols is to clearly delineate various groups of functionality
+;; so we can improve the composability of the Overtone building blocks.  Our current synths
+;; and instruments grew out of a desire to make things easy to use, but we need to refactor them
+;; split-up unneccessarily bound aspects of functionality, and then create new "easy" APIs using
+;; these refactored elements.
 
-; Synths:
-; * synth definition
-; * filling of default parameter settings from atoms
-; * mixed argument handling (in-order and/or keyword)
-; * implements trigger, ctl and kill for single synth instances
-; * places synth nodes in a default synth group
+;; Synths:
+;; * synth definition
+;; * filling of default parameter settings from atoms
+;; * mixed argument handling (in-order and/or keyword)
+;; * implements trigger, ctl and kill for single synth instances
+;; * places synth nodes in a default synth group
 
-; Instruments:
-; * allocates an output bus for all instances of the synth
-; * appends the out ugen to automatically use the correct bus
-; * allocates groups:
-;  - inst container group
-;  - instance group
-;  - fx group
-;  - mixer group
-; * implements ctl and kill for all instances
+;; Instruments:
+;; * allocates an output bus for all instances of the synth
+;; * appends the out ugen to automatically use the correct bus
+;; * allocates groups:
+;;  - inst container group
+;;  - instance group
+;;  - fx group
+;;  - mixer group
+;; * implements ctl and kill for all instances
 
-; This bundling of functionality has led to two issues that demonstrate some of the problems:
-; * Many synth designs are very general purpose, and with different settings they can sound like completely different instruments.  Currently the only way to use the same instrument multiple times in Overtone with different parameter settings is to copy/paste the definst and give it a new name.  Instead we need a way to build a "voice" given a synth design and a set of parameters.
+;; This bundling of functionality has led to two issues that demonstrate some of the problems:
+;; * Many synth designs are very general purpose, and with different settings they can sound like completely different instruments.  Currently the only way to use the same instrument multiple times in Overtone with different parameter settings is to copy/paste the definst and give it a new name.  Instead we need a way to build a "voice" given a synth design and a set of parameters.
 
-; * Audio samples and the memory buffers they get loaded into can be single or multi-channel, but a synth design must have a fixed number of channels.  We need to define a protocol for triggering synths so we can implement higher level "meta-synths" that can actually use multiple underlying synths depending on the number of channels of the input buffer.  Many other kinds of meta-synths could exist that either generate synth definitions on the fly, or choose the most appropriate for the task.
+;; * Audio samples and the memory buffers they get loaded into can be single or multi-channel, but a synth design must have a fixed number of channels.  We need to define a protocol for triggering synths so we can implement higher level "meta-synths" that can actually use multiple underlying synths depending on the number of channels of the input buffer.  Many other kinds of meta-synths could exist that either generate synth definitions on the fly, or choose the most appropriate for the task.
 
-; To begin lets try to isolate this functionality into simpler units:
-; * synth definition
-; * mixed argument handling
-; * stored default parameters
-; * trigger, control and kill
-; * bus allocation and automatic append of out ugen
-; * automatic instance placement
-                                        ; * group allocation and fx/mixer setup
+;; To begin lets try to isolate this functionality into simpler units:
+;; * synth definition
+;; * mixed argument handling
+;; * stored default parameters
+;; * trigger, control and kill
+;; * bus allocation and automatic append of out ugen
+;; * automatic instance placement
+;; * group allocation and fx/mixer setup
 
 (defonce ^{:private true}
   _PROTOCOLS_

--- a/src/overtone/sc/foundation_groups.clj
+++ b/src/overtone/sc/foundation_groups.clj
@@ -1,14 +1,14 @@
-(ns
-    ^{:doc "Foundation Group Structure"
-      :author "Sam Aaron"}
-  overtone.sc.foundation-groups
-  (:use [overtone.libs.deps                 :only [on-deps satisfy-deps]]
-        [overtone.libs.event                :only [on-sync-event]]
-        [overtone.sc.node                   :only [group group-deep-clear group-clear]]
-        [overtone.sc.server                 :only [ensure-connected!]]
-        [overtone.sc.defaults               :only [foundation-groups* empty-foundation-groups]]
-        [overtone.sc.server                 :only [clear-msg-queue]]
-        [overtone.sc.machinery.server.comms :only [with-server-sync]]))
+(ns overtone.sc.foundation-groups
+  "Foundation Group Structure"
+  {:author "Sam Aaron"}
+  (:require
+   [overtone.libs.deps                 :refer [on-deps satisfy-deps]]
+   [overtone.libs.event                :refer [on-sync-event]]
+   [overtone.sc.node                   :refer [group group-deep-clear group-clear]]
+   [overtone.sc.server                 :refer [ensure-connected!]]
+   [overtone.sc.defaults               :refer [foundation-groups* empty-foundation-groups]]
+   [overtone.sc.server                 :refer [clear-msg-queue]]
+   [overtone.sc.machinery.server.comms :refer [with-server-sync]]))
 
 (defn- setup-foundation-groups
   []

--- a/src/overtone/sc/machinery/server/connection.clj
+++ b/src/overtone/sc/machinery/server/connection.clj
@@ -292,7 +292,9 @@
                                                           sc-wellknown
                                                           (str "well-known location for " (name (get-os))))
               ")")
-    (str match)))
+    (if (coll? match)
+      (mapv str match)
+      [(str match)])))
 
 (defn- has-pipewire? []
   (some #(some->> % :command (re-find #"/pipewire$")) (process-info/ps)))
@@ -306,7 +308,7 @@
   process (typically with #'external-booter)."
   [opts]
   (into-array String
-              (cond->> (cons (scsynth-path) (scsynth-arglist opts))
+              (cond->> (into (scsynth-path) (scsynth-arglist opts))
                 ;; pw-jack adds PipeWire's Jack implementation to the
                 ;; LD_LIBRARY_PATH, so that Jack applications work with PipeWire
                 ;; instead of looking for original jackd. This might save some

--- a/src/overtone/sc/node.clj
+++ b/src/overtone/sc/node.clj
@@ -65,7 +65,7 @@
       (group-free [group]
         "Destroys this group and any containing synths or subgroups."))))
 
-(extend-type java.lang.Long to-sc-id*    (to-sc-id [v] v))
+(extend-type java.lang.Long to-sc-id* (to-sc-id [v] v))
 (extend-type java.lang.Integer to-sc-id* (to-sc-id [v] v))
 (extend-type java.lang.Float to-sc-id* (to-sc-id [v] v))
 

--- a/src/overtone/sc/sample.clj
+++ b/src/overtone/sc/sample.clj
@@ -100,9 +100,10 @@
        NOTE: This was very prone to clicking at the end, so for now it uses
        playbuf until we can figure out a way to make this work without
        clicking. This means start/end/release currently don't do anything."
-      [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 release 0 out-bus 0]
+      [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 pan 0 release 0 out-bus 0]
       (out out-bus
-           (* amp (play-buf 1 buf :loop loop? :rate rate :action FREE)))
+           (pan2
+            (* amp (play-buf 1 buf :loop loop? :rate rate :action FREE))))
       #_(let [n-frames  (buf-frames buf)
               rate      (* rate (buf-rate-scale buf))
               start-pos (* start n-frames)

--- a/src/overtone/sc/sample.clj
+++ b/src/overtone/sc/sample.clj
@@ -95,35 +95,46 @@
       "Plays a mono buffer from start pos to end pos (represented as
        values between 0 and 1). May be looped via the loop?
        argument. Release time is the release phase after the looping has
-       finished to remove clipping."
+       finished to remove clipping.
+
+       NOTE: This was very prone to clicking at the end, so for now it uses
+       playbuf until we can figure out a way to make this work without
+       clicking. This means start/end/release currently don't do anything."
       [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 release 0 out-bus 0]
-      (let [n-frames  (buf-frames buf)
-            rate      (* rate (buf-rate-scale buf))
-            start-pos (* start n-frames)
-            end-pos   (* end n-frames)
-            phase     (phasor:ar :start start-pos :end end-pos :rate rate)
-            snd       (buf-rd 1 buf phase)
-            e-gate    (+ loop?
-                         (a2k (latch:ar (line 1 0 0.0001) (bpz2 phase))))
-            env       (env-gen (asr 0 1 release) :gate e-gate :action FREE)]
-        (out out-bus (* amp env snd))))
+      (out out-bus
+           (* amp (play-buf 1 buf :loop loop? :rate rate :action FREE)))
+      #_(let [n-frames  (buf-frames buf)
+              rate      (* rate (buf-rate-scale buf))
+              start-pos (* start n-frames)
+              end-pos   (* end n-frames)
+              phase     (phasor:ar :start start-pos :end end-pos :rate rate)
+              snd       (buf-rd 1 buf phase)
+              e-gate    (+ loop?
+                           (a2k (latch:ar (line 1 0 0.0001) (bpz2 phase))))
+              env       (env-gen (asr 0 1 release) :gate e-gate :action FREE)]
+          (out out-bus (* amp env snd))))
 
     (defsynth stereo-partial-player
-      "Plays a stereo buffer from start pos to end pos (represented as
-       values between 0 and 1). May be looped via the loop?
-       argument. Release time is the release phase after the looping has
-       finished to remove clipping."
+      "Plays a stereo buffer from start pos to end pos (represented as values
+       between 0 and 1). May be looped via the loop? argument. Release time is
+       the release phase after the looping has finished to remove clipping.
+
+       NOTE: This was very prone to clicking at the end, so for now it uses
+       playbuf until we can figure out a way to make this work without
+       clicking. This means start/end/release currently don't do anything."
       [buf 0 rate 1 start 0 end 1 loop? 0 amp 1 release 0 out-bus 0]
-      (let [n-frames  (buf-frames buf)
-            rate      (* rate (buf-rate-scale buf))
-            start-pos (* start n-frames)
-            end-pos   (* end n-frames)
-            phase     (phasor:ar :start start-pos :end end-pos :rate rate)
-            snd       (buf-rd 2 buf phase)
-            e-gate    (+ loop?
-                         (a2k (latch:ar (line 1 0 0.0001) (bpz2 phase))))
-            env       (env-gen (asr 0 1 release) :gate e-gate :action FREE)]
-        (out out-bus (* amp env snd))))
+      (out out-bus
+           (* amp (play-buf 2 buf :loop loop? :rate rate :action FREE)))
+      #_(let [n-frames  (buf-frames buf)
+              rate      (* rate (buf-rate-scale buf))
+              start-pos (* start n-frames)
+              end-pos   (* end n-frames)
+              phase     (phasor:ar :start start-pos :end end-pos :rate rate)
+              snd       (buf-rd 2 buf phase)
+              e-gate    (+ loop?
+                           (a2k (latch:ar (line 1 0 0.0001) (bpz2 phase))))
+              env       (env-gen (asr 0 1 release) :gate e-gate :action FREE)]
+          (out out-bus (* amp env snd))))
 
     (defsynth mono-stream-player
       "Plays a single channel streaming buffer-cue. Must be freed manually when

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -1,12 +1,19 @@
 (ns overtone.studio.event
   (:require
-   [overtone.studio.pattern :as pattern]
+   [overtone.at-at :as at-at]
    [overtone.libs.event :as event]
    [overtone.music.pitch :as pitch]
    [overtone.music.time :as time]
    [overtone.sc.node :as node]
+   [overtone.sc.sample :as sample]
    [overtone.sc.server :as server]
+   [overtone.studio.pattern :as pattern]
    [overtone.studio.transport :as transport]))
+
+(defonce
+  ^{:doc "Thread pool for `at-at`, separate from the main pool overtone
+  uses so we can control the behavior when `stop` is called (:reset event)"}
+  player-pool (at-at/mk-pool))
 
 (defonce pplayers (atom {}))
 
@@ -50,8 +57,19 @@
     :strum            0}
 
    :ctl
-   {:type :ctl
-    :dur  1}})
+   {:type   :ctl
+    :dur    1
+    :root   0.0
+    :octave 5.0
+    :gtranspose       0.0
+    :steps-per-octave 12.0
+    :octave-ratio     2.0
+    :harmonic         1.0
+    :ctranspose       0.0
+    :detune           0.0
+    :swing-quant      2
+    :swing            0
+    }})
 
 (declare derivations)
 
@@ -70,7 +88,7 @@
                         {:event e}))))))
 
 (defn rest? [o]
-  (#{:_ :rest} o))
+  (#{:_ :- :rest} o))
 
 (defn- octave-note [e octave note]
   (* (+ octave
@@ -166,8 +184,18 @@
   {:freq :detuned-freq
    :note :midinote})
 
+(defn eget-instrument [e]
+  (let [i (eget e :instrument)]
+    (if (or (instance? overtone.sc.sample.PlayableSample i)
+            (instance? overtone.samples.freesound.FreesoundSample i))
+      (case (:n-channels i)
+        1 sample/mono-partial-player
+        2 sample/stereo-partial-player)
+      i)))
+
 (defn params-vec [e]
-  (let [i (eget e :instrument)
+  (let [i' (eget e :instrument)
+        i (eget-instrument e)
         params (or (:params (meta i))
                    (map (comp keyword :name)
                         (:pnames (:sdef i))))]
@@ -176,12 +204,14 @@
                 (if (or (contains? e lk) (contains? derivations lk))
                   (conj acc kn (eget e lk))
                   acc)))
-            []
+            (if (instance? overtone.sc.sample.PlayableSample i')
+              [:buf (:id i')]
+              [])
             params)))
 
 (defn handle-note [e]
   (when-not (keyword? (eget e :freq))
-    (let [i         (eget e :instrument)
+    (let [i         (eget-instrument e)
           params    (:params i)
           args      (params-vec e)
           has-gate? (some #{"gate"} (map :name params))
@@ -225,7 +255,7 @@
                                   :midinote n))))))
 
 (defn handle-ctl [e]
-  (let [i (eget e :instrument)
+  (let [i (eget-instrument e)
         args (params-vec e)
         start (eget e :start-time)]
     (when start
@@ -235,37 +265,64 @@
 (event/on-event :chord #'handle-chord ::chord)
 (event/on-event :ctl #'handle-ctl ::ctl)
 
-(defn- quantize
-  "Quantize a beat to a period, made a bit awkward by the fact that beats counts
-  from 1, so e.g. a quant of 4 (align to 4/4 bars), yields 1, 5, 9, etc."
+(defn- quantize-ceil
+  "Quantize a beat to a period, rounding up.
+
+  Made a bit awkward by the fact that beats counts from 1, so e.g. a quant of
+  4 (align to 4/4 bars), yields 1, 5, 9, etc."
   [beat quant]
   (let [m (mod (dec beat) quant)]
     (if (= 0 m)
       beat
       (+ beat (- quant m)))))
 
-(defn schedule-next [k]
-  (let [pp @pplayers
-        {:keys [clock paused? pseq beat proto] :as player} (get pp k)
-        e        (merge {:clock transport/*clock*}
-                        (pattern/pfirst pseq)
-                        proto)
-        dur      (eget e :dur)
-        type     (eget e :type)
-        next-seq (pattern/pnext pseq)]
-    (if (and next-seq (not paused?))
-      (let [job (time/apply-by (clock (+ beat dur -0.5)) schedule-next [k])]
-        (swap! pplayers update k assoc
-               :job job
-               :pseq next-seq
-               :beat (+ beat dur)))
-      (swap! pplayers dissoc k))
+(defn- quantize-floor
+  "Quantize a beat to a period, rounding up.
 
-    (when (seq pseq)
-      (event/event (eget e :type) (assoc e :beat beat :clock clock)))))
+  Made a bit awkward by the fact that beats counts from 1, so e.g. a quant of
+  4 (align to 4/4 bars), yields 1, 5, 9, etc."
+  [beat quant]
+  (let [m (mod (dec beat) quant)]
+    (if (= 0 m)
+      beat
+      (- beat m))))
+
+(declare schedule-next)
+
+(defn schedule-next-job [clock beat k]
+  (time/with-pool player-pool
+    (time/apply-by (clock (dec beat)) schedule-next [k])))
+
+(defn player-schedule-next [{:keys [clock playing pseq beat proto] :as player}]
+  (if (or (not playing) (not player))
+    player
+    (let [e         (merge {:clock transport/*clock*}
+                           (pattern/pfirst pseq)
+                           proto)
+          dur       (eget e :dur)
+          type      (eget e :type)
+          next-seq  (pattern/pnext pseq)
+          next-beat (+ beat dur)]
+      (if next-seq
+        (assoc player
+               :pseq next-seq
+               :beat next-beat
+               :last-event (assoc e :beat beat :clock clock))
+        nil))))
+
+(defn schedule-next [k]
+  (let [[old new] (map k (swap-vals! pplayers update k player-schedule-next))
+        {:keys [clock beat playing] :as player} new
+        e (:last-event new)]
+    (println (dissoc e :clock))
+    (when playing
+      (when (not= (:last-event new) (:last-event old))
+        (event/event (eget e :type) e))
+      (schedule-next-job clock beat k)))
+  nil)
 
 (defn padd [k pattern & {:keys [quant clock offset] :as opts
-                         :or   {quant 1
+                         :or   {quant 4
                                 offset 0
                                 clock transport/*clock*}}]
   (let [pattern (cond-> pattern (map? pattern) pattern/pbind)]
@@ -277,32 +334,52 @@
                      :pattern pattern
                      :pseq    pattern
                      :quant   quant
-                     :offset  offset
-                     :paused? (if (some? (:paused? p))
-                                (:paused? p)
-                                true)}
+                     :offset  offset}
                     opts)))))
 
+(defn align-pseq [beat quant pseq]
+  (let [next-beat (mod beat quant)
+        [diff pseq] (loop [nb next-beat
+                           ps pseq]
+                      ;; (prn nb ps)
+                      (if (< 0 nb)
+                        (let [dur (eget (pattern/pfirst ps) :dur)]
+                          (recur (- nb dur) (pattern/pnext ps)))
+                        [nb ps]))]
+    [(- beat diff) pseq]))
+
+(comment
+  (def ps
+    (overtone.studio.pattern/pbind {:note [:a :b :c :d :e]
+                                    :dur [1 1/2 1 1/16 1/32 1/8]}))
+
+  [(= [0 ps] (align-pseq 0 4 ps))
+   (= [1 (next ps)] (align-pseq 1/2 4 ps))
+   (= [3/2 (next (next ps))] (align-pseq 5/4 4 ps))
+   (= [4 ps] (align-pseq 4 4 ps))
+   (= [1 (next ps)] (align-pseq 1 2 ps))
+   (= [5 (next ps)] (align-pseq 5 4 ps))
+   (= [5/2 (drop 3 ps)] (align-pseq 2 4 ps))
+   (= [13/2 (drop 3 ps)] (align-pseq 6 4 ps))])
+
+(defn player-resume [{:keys [clock beat pseq quant offset]
+                      :as   player}]
+  (let [beat (max (or beat 0) (clock))
+        [beat pseq] (align-pseq (dec beat) quant pseq)]
+    (assoc player
+           :playing true
+           :beat (inc beat)
+           :pseq pseq)))
+
 (defn presume [k]
-  (let [pp @pplayers
-        {:keys [clock paused? beat quant offset job]
-         :as   player} (get pp k)
-        next-beat (+ (quantize (clock) quant) offset)]
-    (when job
-      (time/kill-player job))
-    (let [job (time/apply-by (clock (- next-beat 0.5)) schedule-next [k])]
-      (swap! pplayers update k
-             assoc
-             :job job
-             :paused? false
-             :beat next-beat)))
+  (let [[old new] (map k (swap-vals! pplayers update k player-resume))]
+    (when (and (not (:playing old))
+               (:playing new))
+      (schedule-next-job (:clock new) (:beat new) k)))
   nil)
 
 (defn ppause [k]
-  (when-let [job (get-in @pplayers [k :job])]
-    (time/kill-player job))
-  (swap! pplayers update k
-         assoc :paused? true :job nil)
+  (swap! pplayers update k assoc :playing false)
   nil)
 
 (defn pplay
@@ -323,14 +400,30 @@
   (presume k)
   nil)
 
+(defn ploop [k pattern & args]
+  (apply pplay k (repeat (pattern/pbind pattern)) args))
+
 (defn premove [k]
-  (when-let [job (get-in @pplayers [k :job])]
-    (time/kill-player job))
   (swap! pplayers dissoc k)
   nil)
 
 (defn pclear []
-  (doseq [job (keep :job (vals @pplayers))]
-    (time/kill-player job))
+  (at-at/stop-and-reset-pool! player-pool :strategy :kill)
   (reset! pplayers {})
   nil)
+
+(event/on-sync-event
+ :reset
+ (fn [event-info]
+   (swap! pplayers
+          (fn [pp]
+            (update-vals pp #(assoc % :playing false))))
+   (at-at/stop-and-reset-pool! player-pool :strategy :kill))
+ ::pplayers-reset)
+
+(comment
+  (update-vals @pplayers #(dissoc % :pseq :pattern))
+
+  (dissoc new :pseq :pattern)
+
+  (at-at/show-schedule player-pool))

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -395,8 +395,11 @@
   - `:quant` start the pattern at a beat number that is a multiple of `:quant`
   "
   [k pattern & args]
-  (apply padd k pattern args)
-  (presume k)
+  (if (= \_ (first (name k)))
+    (ppause (keyword (namespace k) (subs (name k) 1)))
+    (do
+      (apply padd k pattern args)
+      (presume k)))
   nil)
 
 (defn ploop [k pattern & args]


### PR DESCRIPTION
## Fixed

- Pattern library: make patterns more easily redefinable while maintaining the
  same relative position, for smoother live updates
- Accept `:-` as a rest note, in addition to `:_` and `:rest`
- Recognize samples in the pattern player, so things like `:amp` work
- Metronome: also accept `:start` and `:bar-start`, instead of just `:bpm`
- Allow the default `at-at` threadpool to be overridden by a dynvar
  (`*current-pool*`)
- `:sc-path` in `~/.overtone/config.clj` can now be a vector instead of a
  string, for passing additional arguments
- `grunge-bass` : make the amp parameter do something

## Changed

- Changed the implementation of the sample player to a more basic version based
  on `play-buf`, since the old version caused clicks at the end of the sample.
  This does mean currently looping is broken.
