### PR TITLE
Change `distort'` parameter to `distort` to match example uses

### DIFF
--- a/src/overtone/synth/stringed.clj
+++ b/src/overtone/synth/stringed.clj
@@ -68,7 +68,7 @@
         ~'pre-amp   {:default 6.0   :min 0.0 :max 10.0}
         ~'amp       {:default 1.0   :min 0.0 :max 10.0}
         ;; by default, no distortion, no reverb, no low-pass
-        ~'distort'  {:default 0.0   :min 0.0 :max 0.9999999999}
+        ~'distort   {:default 0.0   :min 0.0 :max 0.9999999999}
         ~'rvb-mix   {:default 0.0   :min 0.0 :max 1.0}
         ~'rvb-room  {:default 0.0   :min 0.0 :max 1.0}
         ~'rvb-damp  {:default 0.0   :min 0.0 :max 1.0}
@@ -89,7 +89,7 @@
                            ~note-gate-pairs)
              src# (~'* ~'pre-amp (mix strings#))
              ;; distortion from fx-distortion2
-             k#   (~'/ (~'* 2 ~'distort') (~'- 1 ~'distort'))
+             k#   (~'/ (~'* 2 ~'distort) (~'- 1 ~'distort))
              dis# (~'/ (~'* src# (~'+ 1 k#))
                    (~'+ 1 (~'* k# (~'abs src#))))
              vrb# (free-verb dis# ~'rvb-mix ~'rvb-room ~'rvb-damp)


### PR DESCRIPTION
The addition of the `'` suffix to the name may have been accidental or may have been to avoid a linter warning that `distort` shadows the `distort` fn name. Running clj-kondo with linter configuration set up in https://github.com/overtone/overtone/pull/493 does not show corrected name as an error or warning.

This is a (tiny) breaking change that makes the existing guitar-synth or slide-guitar examples work correctly and makes the parameter less unusual.