### PR TITLE
Fix reflection warnings

### DIFF
--- a/src/overtone/algo/chance.clj
+++ b/src/overtone/algo/chance.clj
@@ -4,6 +4,8 @@
   (:use
    [overtone.algo.scaling]))
 
+(set! *warn-on-reflection* true)
+
 (defn choose
   "Choose a random element from col."
   [col]
@@ -42,7 +44,8 @@
            sorted (sort #(< (first %1) (first %2)) paired)
            summed (loop [todo sorted
                          done []
-                         cumulative 0]
+                         ;; probabilities are floats
+                         cumulative 0.0]
                     (if (empty? todo)
                       done
                       (let [f-prob (ffirst todo)

--- a/src/overtone/helpers/doc.clj
+++ b/src/overtone/helpers/doc.clj
@@ -3,6 +3,8 @@
   {:author "Sam Aaron"}
   (:require [clojure.string :as str]))
 
+(set! *warn-on-reflection* true)
+
 (def DOC-WIDTH 50)
 
 (defn length-of-longest-key
@@ -12,7 +14,7 @@
    (length-of-longest-key {}) ;=> 0"
 
   [m]
-  (or (last (sort (map #(.length %) (keys m))))
+  (or (last (sort (map count (keys m))))
       0))
 
 (defn length-of-longest-string
@@ -40,8 +42,8 @@
   [s ls cur-len max-len indent]
   (if (empty? ls)
     s
-    (let [f-len (.length (first ls))]
-      (if (.endsWith (first ls) "\n\n")
+    (let [f-len (count (first ls))]
+      (if (str/ends-with? (first ls) "\n\n")
         (if (> (+ cur-len f-len) max-len)
           (indented-str-block* (str s "\n" (gen-padding indent) (first ls) (gen-padding indent)) (rest ls) 0 max-len indent)
           (indented-str-block* (str s (first ls) (gen-padding indent)) (rest ls) 0 max-len indent))

--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -15,6 +15,8 @@
                   FileVisitResult LinkOption CopyOption)
    (java.nio.file.attribute FileAttribute)))
 
+(set! *warn-on-reflection* true)
+
 (def ^{:dynamic true} *verbose-overtone-file-helpers* false)
 (def ^{:dynamic true} *authorization-header* false)
 
@@ -409,7 +411,7 @@
     (visitFile [^java.nio.file.Path file attrs]
       (let [^java.nio.file.Path target (.resolve to (.relativize from file))]
         (Files/copy file target
-                    ^java.nio.file.CopyOption (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING])))
+                    ^"[Ljava.nio.file.CopyOption;" (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING])))
       FileVisitResult/CONTINUE)))
 
 (defn copy-dir!
@@ -435,7 +437,8 @@
                              " attempts. URL attempted to download: "
                              url ))))
 
-   (let [path (resolve-tilde-path path)]
+   (let [wait-t (long wait-t)
+         path (resolve-tilde-path path)]
      (try
        (download-file-with-timeout url path timeout)
        (catch java.io.FileNotFoundException e

--- a/src/overtone/helpers/lib.clj
+++ b/src/overtone/helpers/lib.clj
@@ -5,11 +5,13 @@
   (:import [java.util ArrayList Collections]
            [java.util.concurrent TimeUnit TimeoutException]
            [java.io File])
+  (:require [clojure.string :as str])
   (:use [clojure.stacktrace]
         [clojure.pprint]
         [overtone.helpers doc]
         [overtone.helpers.system :only [windows-os?]]))
 
+(set! *warn-on-reflection* true)
 
 (defn to-str
   "If val is a keyword, return its name sans :, otherwise return val"
@@ -332,7 +334,7 @@
    SuperCollider names to Overtone names. Most likely needs improvement.
 
   (overtone-ugen-name \"SinOsc\") ;=> \"sin-osc\""
-  [n]
+  [^String n]
   (when-not (string? n)
     (throw (IllegalArgumentException. (str "Cannot convert non-string obj " (with-out-str (pr n)) " to an overtone ugen name"))))
 
@@ -369,7 +371,7 @@
     (let [p-files   (map str (concat
                               (env-files "PROGRAMFILES")
                               (env-files "PROGRAMFILES(X86)")))
-          sc-files  (filter #(.contains % "SuperCollider") p-files)
+          sc-files  (filter #(str/includes? % "SuperCollider") p-files)
           recent-sc (last (sort (seq sc-files)))]
       recent-sc)))
 

--- a/src/overtone/libs/handlers.clj
+++ b/src/overtone/libs/handlers.clj
@@ -2,8 +2,10 @@
     ^{:doc "A simple event system that handles both synchronous and asynchronous events."
       :author "Jeff Rose & Sam Aaron"}
     overtone.libs.handlers
-  (:import (java.util.concurrent Executors))
+  (:import (java.util.concurrent Executors ExecutorService))
   (:use [clojure.stacktrace]))
+
+(set! *warn-on-reflection* true)
 
 (defrecord HandlerPool [pool handlers desc])
 
@@ -201,7 +203,7 @@
       (run-handler k handler event-map hp))))
 
 (defn- emhs-handle-async-one-shots
-  [emhs event-map pool hp]
+  [emhs event-map ^ExecutorService pool hp]
   (let [keyed-fns (apply merge (map (fn [emh] (:async-one-shots emh)) emhs))]
     (if *FORCE-SYNC?*
       (run-one-shot-handlers keyed-fns event-map hp)
@@ -216,7 +218,7 @@
   "Runs all async handlers in a thread pool. If binding *FORCE-SYNC?*
   is true, forces async handlers to execute synchronously on the
   current thread."
-  [emhs event-map pool hp]
+  [emhs event-map ^ExecutorService pool hp]
   (let [keyed-fns (apply merge (map (fn [emh] (:asyncs emh)) emhs))]
     (if *FORCE-SYNC?*
       (run-handlers keyed-fns event-map hp)

--- a/src/overtone/midi.clj
+++ b/src/overtone/midi.clj
@@ -12,6 +12,8 @@
    (javax.sound.midi MidiDevice MidiDevice$Info MidiSystem Receiver Sequencer ShortMessage Synthesizer SysexMessage Transmitter)
    (javax.swing DefaultListModel JFrame JList JScrollPane ListSelectionModel)))
 
+(set! *warn-on-reflection* true)
+
 ;; Java MIDI returns -1 when a port can support any number of transmitters or
 ;; receivers, we use max int.
 
@@ -353,7 +355,8 @@
    (loop [notes notes
           velocities velocities
           durations durations
-          cur-time  0]
+          ;; boxed due to at-at/after
+          cur-time  (num 0)]
      (if notes
        (let [n (first notes)
              v (first velocities)

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -8,6 +8,8 @@
         [overtone.algo chance])
   (:require [clojure.string :as string]))
 
+(set! *warn-on-reflection* true)
+
 ;; Notes in a typical scale are related by small, prime number ratios. Of all
 ;; possible 7 note scales, the major scale has the highest number of consonant
 ;; intervals.
@@ -140,7 +142,7 @@
   [midi-string]
   (let [[match pitch-class octave] (validate-midi-string! midi-string)
         pitch-class                (canonical-pitch-class-name pitch-class)
-        octave                     (when octave (Integer. octave))
+        octave                     (when octave (Integer. ^String octave))
         interval                   (NOTES (keyword pitch-class))]
     (cond-> {:match       match
              :pitch-class pitch-class

--- a/src/overtone/osc/peer.clj
+++ b/src/overtone/osc/peer.clj
@@ -350,7 +350,7 @@
 (defn update-peer-target
   "Update the target address of an OSC client so future calls to osc-send
   will go to a new destination. Also updates zeroconf registration."
-  [peer host ^long port]
+  [peer host port]
   (when-not (integer? port)
     (throw (Exception. (str "port should be an integer - got: " port))))
   (when-not (string? host)
@@ -362,7 +362,7 @@
     (dosync
      (ref-set (:host peer) host)
      (ref-set (:port peer) port)
-     (ref-set (:addr peer) (InetSocketAddress. host port)))
+     (ref-set (:addr peer) (InetSocketAddress. host (int port))))
 
     (when (:zero-conf-name peer)
       (register-zero-conf-service (:zero-conf-name peer) port))))

--- a/src/overtone/osc/peer.clj
+++ b/src/overtone/osc/peer.clj
@@ -3,6 +3,7 @@
            [java.util.concurrent TimeUnit TimeoutException PriorityBlockingQueue]
            [java.nio.channels DatagramChannel AsynchronousCloseException ClosedChannelException]
            [java.nio ByteBuffer]
+           [java.io Writer]
            [javax.jmdns JmDNS ServiceListener ServiceInfo])
   (:use [clojure.set :as set]
         [overtone.osc.util]
@@ -11,6 +12,8 @@
         [overtone.osc.pattern :only [matching-handlers]])
   (:require [overtone.at-at :as at-at]
             [clojure.string :as string]))
+
+(set! *warn-on-reflection* true)
 
 (def zero-conf* (agent nil))
 (def zero-conf-services* (atom {}))
@@ -31,7 +34,7 @@
 (defn turn-zero-conf-off
   "Unregister all zeroconf services and close zeroconf down."
   []
-  (send zero-conf* (fn [zero-conf]
+  (send zero-conf* (fn [^JmDNS zero-conf]
                      (when zero-conf
                        (.unregisterAllServices zero-conf)
                        (.close zero-conf))
@@ -41,7 +44,7 @@
 (defn unregister-zero-conf-service
   "Unregister zeroconf service registered with port."
   [port]
-  (send zero-conf* (fn [zero-conf port]
+  (send zero-conf* (fn [^JmDNS zero-conf port]
                      (swap! zero-conf-services* dissoc port)
                      (let [service (get @zero-conf-services* port)]
                        (when (and zero-conf zero-conf)
@@ -52,7 +55,7 @@
 (defn register-zero-conf-service
   "Register zeroconf service with name service-name and port."
   [service-name port]
-  (send zero-conf* (fn [zero-conf service-name port]
+  (send zero-conf* (fn [^JmDNS zero-conf service-name port]
                      (let [service-name (str service-name " : " port)
                            service (ServiceInfo/create "_osc._udp.local"
                                                        service-name port
@@ -117,7 +120,7 @@
   empty list) and :default (the default listener). Each listener is then
   extracted and called with the message as a param. Before invoking the
   listeners the source host and port are added to the  message map."
-  [all-listeners src msg]
+  [all-listeners ^InetSocketAddress src msg]
   (let [msg              (assoc msg
                                 :src-host (.getHostString src)
                                 :src-port (.getPort src))
@@ -147,8 +150,8 @@
   "Loop for the listen thread to execute in order to receive and handle OSC
   messages. Recieves packets from chan using buf and then handles them either
   as messages or bundles - passing the source information and message itself."
-  [^java.nio.channels.DatagramChannel chan buf running? all-listeners]
-  (while (not (.isBound ^java.net.DatagramSocket (.socket chan)))
+  [^DatagramChannel chan buf running? all-listeners]
+  (while (not (.isBound (.socket chan)))
     (Thread/sleep 1))
   (try
     (while @running?
@@ -228,12 +231,12 @@
 (defn bind-chan!
   "Bind a channel's datagram socket to its local port or the specified one if
   explicitly passed in."
-  ([chan]
-   (let [^java.net.DatagramSocket sock (.socket chan)
+  ([^DatagramChannel chan]
+   (let [sock (.socket chan)
          local-port (.getLocalPort sock)]
      (.bind sock (InetSocketAddress. local-port))))
-  ([chan port]
-   (let [^java.net.DatagramSocket sock (.socket chan)]
+  ([^DatagramChannel chan port]
+   (let [^DatagramSocket sock (.socket chan)]
      (.bind sock (InetSocketAddress. port)))))
 
 (defn peer
@@ -316,7 +319,7 @@
   ([peer path]
    (count (peer-handler-paths peer path))))
 
-(defmethod print-method ::peer [peer w]
+(defmethod print-method ::peer [peer ^Writer w]
   (.write w (format "#<osc-peer: open?[%s] listening?[%s] n-listeners[%s] n-handlers[%s]>" @(:running? peer) (if (:listen-thread peer) true false) (num-listeners peer) (num-handlers peer))))
 
 (defn client-peer
@@ -324,7 +327,7 @@
   Clients also listen for incoming messages (such as responses from the server
   it communicates with."
   ([host port] (client-peer host port true))
-  ([host port send-nested-osc-bundles?]
+  ([host ^long port send-nested-osc-bundles?]
    (when-not (integer? port)
      (throw (Exception. (str "port should be an integer - got: " port))))
    (when-not (string? host)
@@ -341,13 +344,13 @@
               :send-nested-osc-bundles? send-nested-osc-bundles?)
        {:type ::client}))))
 
-(defmethod print-method ::client [peer w]
+(defmethod print-method ::client [peer ^Writer w]
   (.write w (format "#<osc-client: destination[%s:%s] open?[%s] n-listeners[%s] n-handlers[%s]>"  @(:host peer) @(:port peer) @(:running? peer) (num-listeners peer) (num-handlers peer))))
 
 (defn update-peer-target
   "Update the target address of an OSC client so future calls to osc-send
   will go to a new destination. Also updates zeroconf registration."
-  [peer host port]
+  [peer host ^long port]
   (when-not (integer? port)
     (throw (Exception. (str "port should be an integer - got: " port))))
   (when-not (string? host)
@@ -385,25 +388,29 @@
               :zero-conf-name zero-conf-name)
        {:type ::server}))))
 
-(defmethod print-method ::server [peer w]
+(defmethod print-method ::server [peer ^Writer w]
   (.write w (format "#<osc-server: n-listeners[%s] n-handlers[%s] port[%s] open?[%s]>"  (num-listeners peer) (num-handlers peer) @(:port peer) @(:running? peer))))
 
 (defn close-peer
-  "Close a peer, also works for clients and servers."
-  [peer & wait]
-  (when (:zero-conf-name peer)
-    (unregister-zero-conf-service (:port peer)))
-  (dosync (ref-set (:running? peer) false))
-  (.close (:chan peer))
-  (when wait
-    (if (:listen-thread peer)
-      (if (integer? wait)
-        (.join (:listen-thread peer) wait)
-        (.join (:listen-thread peer))))
-    (if (:send-thread peer)
-      (if (integer? wait)
-        (.join (:send-thread peer) wait)
-        (.join (:send-thread peer))))))
+  "Close a peer, also works for clients and servers.
+  Joins closed threads if wait is a true value.
+  Sets a timeout for join if wait is an integer."
+  ([peer] (close-peer peer nil))
+  ([peer wait]
+   (let [^DatagramChannel chan (:char peer)]
+     (when (:zero-conf-name peer)
+       (unregister-zero-conf-service (:port peer)))
+     (dosync (ref-set (:running? peer) false))
+     (.close chan)
+     (when wait
+       (when-some [^Thread thread (:listen-thread peer)]
+         (if (integer? wait)
+           (.join thread (long wait))
+           (.join thread)))
+       (when-some [^Thread thread (:send-thread peer)]
+         (if (integer? wait)
+           (.join thread (long wait))
+           (.join thread)))))))
 
 (defn peer-send-bundle
   "Send OSC bundle to peer."
@@ -422,8 +429,8 @@
 (defn peer-reply-msg
   "Send OSC msg to peer"
   [peer msg msg-to-reply-to]
-  (let [host (:src-host msg-to-reply-to)
-        port (:src-port msg-to-reply-to)
+  (let [^String host (:src-host msg-to-reply-to)
+        ^Integer port (:src-port msg-to-reply-to)
         addr (InetSocketAddress. host port)]
     (when @osc-debug*
       (print-debug "osc-reply-msg: " msg " to: " host " : " port))
@@ -446,9 +453,9 @@
       (throw (IllegalArgumentException. (str "OSC handle path should be a string"))))
     (when (contains-pattern-match-chars? path)
       (throw (IllegalArgumentException. (str "OSC handle paths may not contain the following chars: " PATTERN-MATCH-CHARS))))
-    (when (.endsWith path "/")
+    (when (string/ends-with? path "/")
       (throw (IllegalArgumentException. (str "OSC handle needs a method name (i.e. must not end with /)"))))
-    (when-not (.startsWith path "/")
+    (when-not (string/starts-with? path "/")
       (throw (IllegalArgumentException. (str "OSC handle needs to start with /"))))
     (let [handlers (:handlers peer)
           path-parts (split-path path)
@@ -466,7 +473,8 @@
                              :done))
     (let [res (try
                 (if timeout
-                  (.get (future @p) timeout TimeUnit/MILLISECONDS) ; Blocks until
+                  (let [^java.util.concurrent.Future f (future @p)]
+                    (.get f timeout TimeUnit/MILLISECONDS)) ; Blocks until
                   @p)
                 (catch TimeoutException t
                   nil)

--- a/src/overtone/osc/peer.clj
+++ b/src/overtone/osc/peer.clj
@@ -327,7 +327,7 @@
   Clients also listen for incoming messages (such as responses from the server
   it communicates with."
   ([host port] (client-peer host port true))
-  ([host ^long port send-nested-osc-bundles?]
+  ([host port send-nested-osc-bundles?]
    (when-not (integer? port)
      (throw (Exception. (str "port should be an integer - got: " port))))
    (when-not (string? host)
@@ -340,7 +340,7 @@
        (assoc peer
               :host (ref host)
               :port (ref port)
-              :addr (ref (InetSocketAddress. host port))
+              :addr (ref (InetSocketAddress. host (int port)))
               :send-nested-osc-bundles? send-nested-osc-bundles?)
        {:type ::client}))))
 

--- a/src/overtone/osc/util.clj
+++ b/src/overtone/osc/util.clj
@@ -1,6 +1,8 @@
 (ns overtone.osc.util
   (:require [clojure.string :as str]))
 
+(set! *warn-on-reflection* true)
+
 (defn print-debug [& msgs]
   (binding [*out* *err*]
     (apply println msgs)))
@@ -16,7 +18,7 @@
 
 (defn contains-pattern-match-chars?
   "Returns true if str contains any pattern-match characters"
-  [str] (some #(.contains str %) PATTERN-MATCH-CHARS))
+  [str] (some #(str/includes? str %) PATTERN-MATCH-CHARS))
 
 ;; TODO: Figure out how to detect a byte array correctly...
 (defn osc-type-tag
@@ -71,8 +73,8 @@
   * 0 or more args (where the number of args equals the number of types
     in the type tag"
   [path type-tag & args]
-  (let [type-tag (if (and type-tag (.startsWith type-tag ","))
-                   (.substring type-tag 1)
+  (let [type-tag (if (and type-tag (str/starts-with? type-tag ","))
+                   (subs type-tag 1)
                    type-tag)]
     (with-meta {:path path
                 :type-tag type-tag

--- a/src/overtone/repl/debug.clj
+++ b/src/overtone/repl/debug.clj
@@ -9,6 +9,8 @@
    overtone.helpers.lib
    overtone.studio.inst))
 
+(set! *warn-on-reflection* true)
+
 (defn- control-ugen-name?
   [ug-n]
   (or (= "trig-control" ug-n)
@@ -120,7 +122,7 @@
         (if (and (= c-name (overtone-ugen-name (:name ug)) )
                  (= rate (REVERSE-RATES (:rate ug))))
           result
-          (recur (+ result (:n-outputs ug)) (rest ugs)))))))
+          (recur (+ result (long (:n-outputs ug))) (rest ugs)))))))
 
 (defn- expand-control-ug
   [ug c-idx sdef]

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -10,6 +10,8 @@
    [overtone.studio.pattern :as pattern]
    [overtone.studio.transport :as transport]))
 
+(set! *warn-on-reflection* true)
+
 (defonce
   ^{:doc "Thread pool for `at-at`, separate from the main pool overtone
   uses so we can control the behavior when `stop` is called (:reset event)"}
@@ -203,7 +205,7 @@
 (defn- eget-instrument [e]
   (let [i (eget e :instrument)]
     (if (sample/sample? i)
-      (case (:n-channels i)
+      (case (int (:n-channels i))
         1 sample/mono-partial-player
         2 sample/stereo-partial-player)
       i)))
@@ -220,7 +222,7 @@
                                (eget e lk))]
                   (conj acc kn val)
                   acc)))
-            (if (sample? i')
+            (if (sample/sample? i')
               [:buf (:id i') ]
               [])
             params)))


### PR DESCRIPTION
Close #537

I was conservative about autoboxing warnings based on my reading of https://clojure.org/reference/java_interop#optimization

The remaining warnings are fixed by https://github.com/overtone/at-at/pull/26

overtone.studio.event doesn't compile so I fixed it. I also fixed a different bug where a list was being tested for `integer?`.

```clojure
user=> (set! *warn-on-reflection* true)
true
user=> (use 'overtone.live)
--> Loading Overtone...
Reflection warning, overtone/at_at.clj:15:3 - reference to field printStackTrace can't be resolved.
Reflection warning, overtone/at_at.clj:211:16 - call to java.util.concurrent.ScheduledThreadPoolExecutor ctor can't be resolved.
```