### PR TITLE
Rename {and,or,xor} ugens to bit-{and,or,xor}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - `with-overloaded-ugens` and macros that use it (like `def{inst,synth}`)
     will no longer shadow/bind `{and,or,xor}` but will now shadow `bit-{and,or,xor}`
   - renamed ugens will overload to `clojure.core/bit-{and,or,xor}` for numeric
-    arguments
+    arguments and are foldable
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Breaking Changes
 - `{and,or,xor}` ugens have been renamed `bit-{and,or,xor}`
   - `with-overloaded-ugens` and macros that use it (like `def{inst,synth}`)
-    will no longer shadow `{and,or,xor}` but will now shadow `bit-{and,or,xor}`
+    will no longer shadow/bind `{and,or,xor}` but will now shadow `bit-{and,or,xor}`
   - renamed ugens will overload to `clojure.core/bit-{and,or,xor}` for numeric
     arguments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+## Breaking Changes
+- `{and,or,xor}` ugens have been renamed `bit-{and,or,xor}`
+  - `with-overloaded-ugens` and macros that use it (like `def{inst,synth}`)
+    will no longer shadow `{and,or,xor}` but will now shadow `bit-{and,or,xor}`
+  - renamed ugens will overload to `clojure.core/bit-{and,or,xor}` for numeric
+    arguments
+
 ## Added
 
 ## Fixed

--- a/src/overtone/sc/machinery/ugen/metadata/binaryopugen.clj
+++ b/src/overtone/sc/machinery/ugen/metadata/binaryopugen.clj
@@ -59,16 +59,16 @@
                   :doc "Outputs the largest value of the two inputs a
                         and b"}
 
-   "bit-and"     {:summary "Signal comparison - and"
-                  :doc "Performs a bitwise 'and' on the two input signals a and b.
+   "bit-and"     {:summary "Bitwise AND"
+                  :doc "Performs a bitwise AND on the two input signals a and b.
                        Corresponds to bitAnd and the & operator in sclang."}
 
-   "bit-or"      {:summary "Signal comparison - or"
-                  :doc "Performs a bitwise 'or' on the two input signals a and b.
+   "bit-or"      {:summary "Bitwise OR"
+                  :doc "Performs a bitwise OR on the two input signals a and b.
                        Corresponds to bitOr and the | operator in sclang."}
 
-   "bit-xor"     {:summary "Signal comparison - xor"
-                  :doc "Performs a bitwise 'exclusive or' on the two input signals a and b.
+   "bit-xor"     {:summary "Bitwise XOR"
+                  :doc "Performs a bitwise XOR on the two input signals a and b.
                        Corresponds to bitXor in sclang."}
 
    "round"       {:summary "Rounding - nearest multiple"

--- a/src/overtone/sc/machinery/ugen/metadata/binaryopugen.clj
+++ b/src/overtone/sc/machinery/ugen/metadata/binaryopugen.clj
@@ -59,18 +59,17 @@
                   :doc "Outputs the largest value of the two inputs a
                         and b"}
 
-   "and"         {:summary "Signal comparison - and"
-                  :doc "Compares the two input signals a and b. If both
-                        are greater than 0 outputs 1, otherwise outputs 0"}
+   "bit-and"     {:summary "Signal comparison - and"
+                  :doc "Performs a bitwise 'and' on the two input signals a and b.
+                       Corresponds to bitAnd and the & operator in sclang."}
 
-   "or"          {:summary "Signal comparison - or"
-                  :doc "Compares the two input signals a and b. If
-                        either is greater than 0 outputs 1, otherwise
-                        outputs 0"}
+   "bit-or"      {:summary "Signal comparison - or"
+                  :doc "Performs a bitwise 'or' on the two input signals a and b.
+                       Corresponds to bitOr and the | operator in sclang."}
 
-   "xor"         {:summary "Signal comparison - xor"
-                  :doc "Compares the two input signals a and b. If only
-                        one is greater than 0 outputs 1, otherwise outputs 0"}
+   "bit-xor"     {:summary "Signal comparison - xor"
+                  :doc "Performs a bitwise 'exclusive or' on the two input signals a and b.
+                       Corresponds to bitXor in sclang."}
 
    "round"       {:summary "Rounding - nearest multiple"
                   :doc "Rounds a to the nearest (up or down) multiple of

--- a/src/overtone/sc/machinery/ugen/special_ops.clj
+++ b/src/overtone/sc/machinery/ugen/special_ops.clj
@@ -9,7 +9,7 @@
    "not-pos?" 1    ; 0 when a < 0, +1 when a > 0, 1 when a is 0
    ;;"is-nil" 2    ; Defined in UnaryOpUGens.cpp enum but not implemented on the server
    ;;"not-nil" 3   ; Defined in UnaryOpUGens.cpp enum but not implemented on the server
-   ;;"bitNot" 4    ; Defined in UnaryOpUGens.cpp enum but not implemented on the server
+   ;;"bit-not" 4    ; (bitNot) Defined in UnaryOpUGens.cpp enum but not implemented on the server
    "abs" 5         ; absolute value
    ;;"asFloat" 6   ; Defined in UnaryOpUGens.cpp enum but not implemented on the server
    ;;"asInt"   7   ; Defined in UnaryOpUGens.cpp enum but not implemented on the server
@@ -79,9 +79,9 @@
    ">=" 11           ; Greater than or equal to
    "min" 12          ; minimum
    "max" 13          ; maximum
-   "and" 14          ; and (where pos sig is true)
-   "or" 15           ; or (where pos sig is true
-   "xor" 16          ; xor (where pos sig is true)
+   "bit-and" 14      ; bitAnd, & (bitwise and)
+   "bit-or" 15       ; bitOr, | (bitwise or)
+   "bit-xor" 16      ; bitXor (bitwise exclusive or)
    ;;"lcm" 17        ; Defined in BinaryOpUGens.cpp enum but not implemented on the server
    ;;"gcd" 18        ; Defined in BinaryOpUGens.cpp enum but not implemented on the server
    "round" 19        ; Round to nearest multiple
@@ -117,11 +117,11 @@
    })
 
 (def FOLDABLE-BINARY-OPS
-  #{"+" "-" "*" "/" "<" ">" "<=" ">=" "min" "max" "and" "or"})
+  #{"+" "-" "*" "/" "<" ">" "<=" ">=" "min" "max" "bit-and" "bit-or" "bit-xor"})
 
 ;;the following are Clojure fns that can only take numerical args
 (def NUMERICAL-CLOJURE-FNS
-  #{"+" "*" "-" "/" "<" ">" "<=" ">=" "min" "max" "mod" "abs"})
+  #{"+" "*" "-" "/" "<" ">" "<=" ">=" "min" "max" "mod" "abs" "bit-and" "bit-or" "bit-xor"})
 
 (def REVERSE-BINARY-OPS (zipmap (vals BINARY-OPS) (keys BINARY-OPS)))
 

--- a/test/overtone/sc/ugen_collide_test.clj
+++ b/test/overtone/sc/ugen_collide_test.clj
@@ -1,0 +1,53 @@
+(ns overtone.sc.ugen-collide-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [overtone.sc.ugens :as u :refer [gate:kr]]
+            [overtone.sc.machinery.ugen.sc-ugen :as urep]))
+
+;; there used to be ugens called and/or (originally sig-{and,or,xor}).
+;; they were renamed to bit-{and,or} and now clojure.core/{and,or} are not shadowed,
+;; which this test verifies.
+(deftest ugens-colliding-with-macros-test
+  (testing "and is not shadowed"
+    (is (true? (u/with-overloaded-ugens (and))))
+    (is (= 1 (u/with-overloaded-ugens (and 1))))
+    (is (= 1 (u/with-overloaded-ugens (and 1 1))))
+    (is (= 5 (u/with-overloaded-ugens (and 1 2 3 4 5)))))
+  (testing "or is not shadowed"
+    (is (nil? (u/with-overloaded-ugens (or))))
+    (is (= 1 (u/with-overloaded-ugens (or 1))))
+    (is (= 1 (u/with-overloaded-ugens (or 1 1))))
+    (is (= 1 (u/with-overloaded-ugens (or 1 nil nil nil nil nil))))
+    (is (= 3 (u/with-overloaded-ugens (or nil nil 3 nil nil))))))
+
+(deftest bit-ops-test
+  (testing "bit-and"
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-and))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-and :force-ugen))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-and 1))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-and 1 :force-ugen))))
+    (is (= 1 (u/with-overloaded-ugens (bit-and 1 1))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-and 1 1 :force-ugen))))
+    (is (= 0 (u/with-overloaded-ugens (bit-and 1 2 3 4 5))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-and 1 2 3 4 5 :force-ugen))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-and 1 2 (gate:kr) 4 5))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-and 1 2 (gate:kr) 4 5 :force-ugen)))))
+  (testing "bit-or"
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-or))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-or :force-ugen))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-or 1))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-or 1 :force-ugen))))
+    (is (= 1 (u/with-overloaded-ugens (bit-or 1 1))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-or 1 1 :force-ugen))))
+    (is (= 7 (u/with-overloaded-ugens (bit-or 1 2 3 4 5))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-or 1 2 (gate:kr) 4 5))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-or 1 2 (gate:kr) 4 5 :force-ugen)))))
+  (testing "bit-xor"
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-xor))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-xor :force-ugen))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-xor 1))))
+    (is (thrown? Exception (u/with-overloaded-ugens (bit-xor 1 :force-ugen))))
+    (is (= 0 (u/with-overloaded-ugens (bit-xor 1 1))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-xor 1 1 :force-ugen))))
+    (is (= 1 (u/with-overloaded-ugens (bit-xor 1 2 3 4 5))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-xor 1 2 (gate:kr) 4 5))))
+    (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-xor 1 2 (gate:kr) 4 5 :force-ugen))))))


### PR DESCRIPTION
Close #536 

The original problem was that the `and/or` ugens "overload" to the Clojure macros, which doesn't work at all (even if it made sense).

I looked into these operators in SC and they're actually bitwise operators, which we already have names for in Clojure. Maybe we could use them?

By renaming the vars, we exchange the macro overloading with function overloading like all the other colliding ugens.

It's hard to tell if these breaking changes are worth it, my thoughts:

`and` and `or` were completely broken for numeric arguments, but probably worked fine as ugens. There's a third case where someone intended to use `clojure.core/{and,or}` but ended up forcing a ugen due to non-numeric args, which is more worrying.

`xor` always worked fine, but it was hard to resist overloading `clojure.core/bit-xor`. In this case, there'll at least be a compile-time error for users of `xor`. Might be nice to have both names.

A final idea, perhaps it's worth decomplecting overloading ugens with colliding ones. So many synths use `java.lang.Math` when there's a perfectly good ugen already there. For example:

```clojure
; (sqrt 10) should call Math/sqrt
; (log 10) should call Math/log
; (exp 10) should call Math/exp
; (floor 10) should call Math/floor
; (ceil 10) should call Math/ceil
; (sign) could be Math/signum, tho that returns a double instead of int
; (log 10) should call (Math/log 10)
; (log2 10) ??
; (log10 10) should call (Math/log10 10)
; (sin 10) should call (Math/sin 10)
; (cos 10) should call (Math/cos 10)
; (tan 10) should call (Math/tan 10)
; (asin 0.5) should call (Math/asin 0.5)
; (acos 0.5) should call (Math/acos 0.5)
; (atan 0.5) should call (Math/atan 0.5)
; (sinh 0.5) should call (Math/sinh 0.5)
; (cosh 0.5) should call (Math/cosh 0.5)
; (tanh 0.5) should call (Math/tanh 0.5)
```