### PR TITLE
Support explicit `require` of `overtone.sc.ugen-collide`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `:sc-path` in `~/.overtone/config.clj` can now be a vector instead of a
   string, for passing additional arguments
 - `grunge-bass` : make the amp parameter do something
+- `overtone.sc.ugen-collide` can now be safely required to access colliding
+  ugens explicitly.
 
 ## Changed
 

--- a/src/overtone/sc/ugen_collide.clj
+++ b/src/overtone/sc/ugen_collide.clj
@@ -1,0 +1,5 @@
+(ns overtone.sc.ugen-collide
+  "UGens that collide with clojure.core vars."
+  (:refer-clojure :only [ns])
+  ;; interns ugens in this ns
+  (:require overtone.sc.machinery.ugen.fn-gen))

--- a/src/overtone/sc/ugens.clj
+++ b/src/overtone/sc/ugens.clj
@@ -106,7 +106,7 @@
 
 (defmacro with-overloaded-ugens
   "Bind symbols for all overloaded ugens (i.e. + - / etc.) to the
-  overloaded fn in the ns overtone.sc.ugen-collider. These fns will
+  overloaded fn in the ns overtone.sc.ugen-collide. These fns will
   revert back to original (Clojure) semantics if not passed with ugen args."
   [& body]
   (let [bindings (flatten (map (fn [[orig overload]]

--- a/src/overtone/sc/ugens.clj
+++ b/src/overtone/sc/ugens.clj
@@ -3,7 +3,9 @@
   functions that act as DSP nodes in the synthesizer definitions used by
   SuperCollider. We generate the UGen functions based on hand written metadata
   about each ugen (ugen directory). (Eventually we hope to get this information
-  dynamically from the server.)"
+  dynamically from the server.)
+  
+  UGens that collide with clojure.core vars are available from overtone.sc.ugen-collide."
   {:author "Jeff Rose & Christophe McKeon"}
   (:use [overtone.sc.machinery.ugen fn-gen]))
 
@@ -104,9 +106,8 @@
 
 (defmacro with-overloaded-ugens
   "Bind symbols for all overloaded ugens (i.e. + - / etc.) to the
-  overloaded fn in the ns overtone.sc.ugen-colliders. These fns will
-  revert back to original
-  (Clojure) semantics if not passed with ugen args. "
+  overloaded fn in the ns overtone.sc.ugen-collider. These fns will
+  revert back to original (Clojure) semantics if not passed with ugen args."
   [& body]
   (let [bindings (flatten (map (fn [[orig overload]]
                                  [orig (symbol ugen-collide-ns-str (str overload))])


### PR DESCRIPTION
I like referring to these ugens explicitly so I can access their docs and refactor them into helpers without having to think about `with-overloaded-ugens`.