### PR TITLE
Enhancements and fixes to `overtone.music.pitch`

### DIFF
--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -6,8 +6,7 @@
   Scientific pitch notation is used to represent notes as strings
   https://en.wikipedia.org/wiki/Scientific_pitch_notation
 
-  We denote Middle C (60) as C4, with octaves ranging from -1 to 9.
-  Only single flats and sharps are supported."
+  We denote Middle C (60) as C4, with octaves ranging from -1 to 9."
   {:author "Jeff Rose, Sam Aaron & Marius Kempe"}
   (:use [overtone.helpers old-contrib]
         [overtone.helpers.map :only [reverse-get]]

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -218,8 +218,6 @@
    10 :Bb
    11 :B})
 
-(declare note-info)
-
 (defn canonical-pitch-class-name
   "Returns the canonical version of pitch class of the provided note.
   Canonical names are the notes of the C major scale
@@ -230,7 +228,7 @@
     (or (REVERSE-NOTES (NOTES note))
         (-> note note-info :pitch-class))))
 
-(def MIDI-NOTE-RE-STR "([a-gA-G][#bB]?)([-0-9]+)?" )
+(def MIDI-NOTE-RE-STR "([a-gA-G][♭♮♯𝄫𝄪#bB]*)([-0-9]+)?")
 (def MIDI-NOTE-RE (re-pattern MIDI-NOTE-RE-STR))
 (def ONLY-MIDI-NOTE-RE (re-pattern (str "\\A" MIDI-NOTE-RE-STR "\\Z")))
 

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -733,7 +733,9 @@
   ([base-freq n] (interval-freq base-freq n :ionian :equal-tempered))
   ([base-freq n scale tuning]
    (case tuning
-     :equal-tempered (nth-equal-tempered-freq base-freq (nth-interval scale n)))))
+     :equal-tempered (nth-equal-tempered-freq base-freq
+                                              ;;TODO unit test, these args were backwards
+                                              (nth-interval scale n)))))
 
 (defn find-scale-name
   "Return the name of the first matching scale found in SCALE

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -458,14 +458,20 @@
     (validate-scale! scale)))
 
 (defn scale-field
-  "Create the note field for a given scale.  Scales are specified with
-  a keyword representing the key and an optional scale
-  name (defaulting to :major):
+  "Create the note field for a given scale in the form of a
+  sorted vector containing all valid MIDI note numbers in the
+  scale starting at root. root is resolved with [[pitch-class]]
+  and scale with [[resolve-scale]] (whose input defaults to :major).
+
+  Scales are specified with a keyword representing the key
+  and an optional scale name (defaulting to :major),
+  or any input 
+
   (scale-field :g)
   (scale-field :g :minor)"
   ([root] (scale-field root nil))
   ([root scale]
-   (let [base (:interval (note-info root))
+   (let [base (pitch-class root)
          intervals (vec (resolve-scale (or scale :major)))
          nintervals (count intervals)]
      (loop [field []

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -403,17 +403,17 @@
          intervals (vec (resolve-scale (or scale :major)))
          nintervals (count intervals)]
      (loop [field []
-            next-note (- base 12)
+            note (- base 12) ;; start 1-12 notes below MIDI-LOWEST-NOTE
             interval-idx (num 0)]
-       (let [new-note (+ next-note (nth intervals interval-idx))]
-         (if (<= MIDI-LOWEST-NOTE new-note)
-           (if (<= new-note MIDI-HIGHEST-NOTE)
-             (recur (conj field new-note)
-                    new-note
+       (let [note (+ note (nth intervals interval-idx))]
+         (if (<= MIDI-LOWEST-NOTE note)
+           (if (<= note MIDI-HIGHEST-NOTE)
+             (recur (conj field note)
+                    note
                     (mod (inc interval-idx) nintervals))
              field)
            (recur field
-                  new-note
+                  note
                   (mod (inc interval-idx) nintervals))))))))
 
 (defn nth-interval

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -5,6 +5,8 @@
   
   Scientific pitch notation is used to represent notes as strings:
     https://en.wikipedia.org/wiki/Scientific_pitch_notation
+
+    FIXME
   Octave is always respected, e.g., Cb4 and B4 are enharmonic.
   Also applies when a default octave is documented, e.g., if the
   default octave is 4, Cb and B4 are enharmonic.

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -37,7 +37,7 @@
           (defn ~rname
             ~(str "Returns the frequency raised by a " doc ".\n"
                   "If not a number, input will be treated as a note.")
-            {:arglists '([freq-or-note])}
+            {:arglists '([~'freq-or-note])}
             [freq#] (* (if (number? freq#)
                          freq#
                          (-> freq# note midi->hz))
@@ -60,7 +60,7 @@
   a logarithmic measurement of pitch, where 1-octave equals 1200
   cents."
   [freq n-cents]
-  (* freq (java.lang.Math/pow 2 (/ n-cents 1200))))
+  (* freq (Math/pow 2 (/ n-cents 1200))))
 
 ;; MIDI
 (def ^:private MIDI-LOWEST-NOTE 0)

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -721,19 +721,19 @@
 
 (defn nth-equal-tempered-freq
   "Returns the frequency of a given scale interval using an
-  equal-tempered tuning i.e. dividing all 12 semi-tones equally across
+  equal-tempered tuning i.e. dividing all 12 semitones equally across
   an octave. This is currently the standard tuning."
   [base-freq interval]
   (* base-freq (java.lang.Math/pow 2 (/ interval 12))))
 
 (defn interval-freq
   "Returns the frequency of the given interval using the specified
-  mode and tuning (defaulting to ionian and equal-tempered
+  scale and tuning (defaulting to ionian and equal-tempered
   respectively)."
   ([base-freq n] (interval-freq base-freq n :ionian :equal-tempered))
-  ([base-freq n mode tuning]
-     (case tuning
-           :equal-tempered (nth-equal-tempered-freq base-freq (nth-interval n mode)))))
+  ([base-freq n scale tuning]
+   (case tuning
+     :equal-tempered (nth-equal-tempered-freq base-freq (nth-interval scale n)))))
 
 (defn find-scale-name
   "Return the name of the first matching scale found in SCALE

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -159,7 +159,9 @@
   class of the note, representing the scale degrees
   of the C chromatic scale."
   [note]
-  (-> pitch-class note-info :interval))
+  (if (int? note)
+    (mod (validate-midi-note-number! note) 12)
+    (-> note note-info :interval)))
 
 (defn octave-note
   "Convert an octave and pitch class to a midi note. Pitch
@@ -243,7 +245,7 @@
               (str "Invalid midi-string. " mk
                    " does not appear to be in MIDI format e.g. C#4"))))
 
-    (let [[match pitch-class ^String octave-str] matches]
+    (let [[match _pitch-class ^String octave-str] matches]
       (when-some [octave (some-> octave-str Integer.)]
         (when-not (<= MIDI-LOWEST-OCTAVE
                       octave
@@ -328,7 +330,7 @@
            look-ahead  (if post-str (str "(?=" post-str ")") "")
            match       (re-find (re-pattern (str look-behind MIDI-NOTE-RE-STR look-ahead)) s)]
        (when match
-         (let [[match pitch-class octave] match]
+         (let [[match _pitch-class _octave] match]
            (note-info match))))))
 
 

--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -3,8 +3,11 @@
   frequencies. This is the place for functions representing general musical
   knowledge, like scales, chords, intervals, etc.
   
-  Scientific pitch notation is used to represent notes as strings
-  https://en.wikipedia.org/wiki/Scientific_pitch_notation
+  Scientific pitch notation is used to represent notes as strings:
+    https://en.wikipedia.org/wiki/Scientific_pitch_notation
+  Octave is always respected, e.g., Cb4 and B4 are enharmonic.
+  Also applies when a default octave is documented, e.g., if the
+  default octave is 4, Cb and B4 are enharmonic.
 
   We denote Middle C (60) as C4, with octaves ranging from -1 to 9."
   {:author "Jeff Rose, Sam Aaron & Marius Kempe"}
@@ -132,10 +135,10 @@
 (defn octave-of
   "Returns the octave of the note. Defaults to 4.
   
-  (sut/octave-of 0) => -1  ;; lowest note is in lowest octave
-  (sut/octave-of 127) => 0  ;; highest note is in highest octave
-  (sut/octave-of :C) => 4  ;; defaults to octave 4
-  (sut/octave-of :B8) => 8"
+  (octave-of 0) => -1  ;; lowest note is in lowest octave
+  (octave-of 127) => 0  ;; highest note is in highest octave
+  (octave-of :C) => 4  ;; defaults to octave 4
+  (octave-of :B8) => 8"
   [note]
   (-> note note-info (:octave 4)))
 

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -113,13 +113,15 @@
      :code code})))
 
 (defn refresh-token! []
-  (handle-token-response
-   (post-request
-    (freesound-url "/oauth2/access_token/")
-    {:client_id *client-id*
-     :client_secret *api-key*
-     :grant_type "refresh_token"
-     :refresh_token (config/store-get :freesound-refresh-token)})))
+  (let [refresh_token (or (config/store-get :freesound-refresh-token)
+                          (throw (ex-info "Missing Freesound refresh token" {})))]
+    (handle-token-response
+      (post-request
+        (freesound-url "/oauth2/access_token/")
+        {:client_id *client-id*
+         :client_secret *api-key*
+         :grant_type "refresh_token"
+         :refresh_token refresh_token}))))
 
 (defn- dialog-box
   "Opens a window with a password field and a button to input an auth token.
@@ -186,30 +188,46 @@
       @done
       (access-token @auth))))
 
+(defn with-authorization-header* [do-request]
+  (binding [*authorization-header*
+            (fn []
+              (when (not @*access-token*)
+                (authorization-instructions))
+              (str "Bearer " @*access-token*))]
+    (try
+      (do-request)
+      (catch clojure.lang.ExceptionInfo e
+        (if (not= 401 (:response-code (ex-data e)))
+          (throw e)
+          (if (config/store-get :freesound-refresh-token)
+            (do (println "Freesound token has expired, refreshing.")
+                (try (refresh-token!)
+                     (catch Exception e
+                       (prn e)
+                       (println "Error while refreshing token, asking for a new token.")
+                       (do
+                         (authorization-instructions)
+                         (do-request))))
+                (try
+                  (do-request)
+                  (catch clojure.lang.ExceptionInfo e
+                    (if (not= 401 (:response-code (ex-data e)))
+                      (throw e)
+                      (do
+                        (println "Refresh didn't help, asking for a new token.")
+                        (authorization-instructions)
+                        (do-request))))))
+            (do
+              (println "Freesound token has expired, but no refresh token present. Asking for a new token.")
+              (authorization-instructions)
+              (do-request))))))))
+
 (defmacro with-authorization-header [b]
-  `(binding [*authorization-header*
-             (fn []
-               (when (not @*access-token*)
-                 (authorization-instructions))
-               (str "Bearer " @*access-token*))]
-     (let [do-request# #(do ~b)]
-       (try
-         (do-request#)
-         (catch clojure.lang.ExceptionInfo e#
-           (if (not= 401 (:response-code (ex-data e#)))
-             (throw e#)
-             (do
-               (println "Freesound token has expired, refreshing.")
-               (refresh-token!)
-               (try
-                 (do-request#)
-                 (catch clojure.lang.ExceptionInfo e#
-                   (if (not= 401 (:response-code (ex-data e#)))
-                     (throw e#)
-                     (do
-                       (println "Refresh didn't help, asking for a new token.")
-                       (reset! *access-token* nil)
-                       (do-request#))))))))))))
+  `(with-authorization-header* #(do ~b)))
+
+;Freesound token has expired, refreshing.
+;Execution error (IOException) at sun.net.www.protocol.http.HttpURLConnection/getInputStream0 (HttpURLConnection.java:1998).
+;Server returned HTTP response code: 400 for URL: https://freesound.org/apiv2/oauth2/access_token/
 
 ;; ## Sound Info
 (defn- info-url

--- a/src/overtone/samples/freesound.clj
+++ b/src/overtone/samples/freesound.clj
@@ -113,15 +113,13 @@
      :code code})))
 
 (defn refresh-token! []
-  (let [refresh_token (or (config/store-get :freesound-refresh-token)
-                          (throw (ex-info "Missing Freesound refresh token" {})))]
-    (handle-token-response
-      (post-request
-        (freesound-url "/oauth2/access_token/")
-        {:client_id *client-id*
-         :client_secret *api-key*
-         :grant_type "refresh_token"
-         :refresh_token refresh_token}))))
+  (handle-token-response
+   (post-request
+    (freesound-url "/oauth2/access_token/")
+    {:client_id *client-id*
+     :client_secret *api-key*
+     :grant_type "refresh_token"
+     :refresh_token (config/store-get :freesound-refresh-token)})))
 
 (defn- dialog-box
   "Opens a window with a password field and a button to input an auth token.
@@ -188,46 +186,30 @@
       @done
       (access-token @auth))))
 
-(defn with-authorization-header* [do-request]
-  (binding [*authorization-header*
-            (fn []
-              (when (not @*access-token*)
-                (authorization-instructions))
-              (str "Bearer " @*access-token*))]
-    (try
-      (do-request)
-      (catch clojure.lang.ExceptionInfo e
-        (if (not= 401 (:response-code (ex-data e)))
-          (throw e)
-          (if (config/store-get :freesound-refresh-token)
-            (do (println "Freesound token has expired, refreshing.")
-                (try (refresh-token!)
-                     (catch Exception e
-                       (prn e)
-                       (println "Error while refreshing token, asking for a new token.")
-                       (do
-                         (authorization-instructions)
-                         (do-request))))
-                (try
-                  (do-request)
-                  (catch clojure.lang.ExceptionInfo e
-                    (if (not= 401 (:response-code (ex-data e)))
-                      (throw e)
-                      (do
-                        (println "Refresh didn't help, asking for a new token.")
-                        (authorization-instructions)
-                        (do-request))))))
-            (do
-              (println "Freesound token has expired, but no refresh token present. Asking for a new token.")
-              (authorization-instructions)
-              (do-request))))))))
-
 (defmacro with-authorization-header [b]
-  `(with-authorization-header* #(do ~b)))
-
-;Freesound token has expired, refreshing.
-;Execution error (IOException) at sun.net.www.protocol.http.HttpURLConnection/getInputStream0 (HttpURLConnection.java:1998).
-;Server returned HTTP response code: 400 for URL: https://freesound.org/apiv2/oauth2/access_token/
+  `(binding [*authorization-header*
+             (fn []
+               (when (not @*access-token*)
+                 (authorization-instructions))
+               (str "Bearer " @*access-token*))]
+     (let [do-request# #(do ~b)]
+       (try
+         (do-request#)
+         (catch clojure.lang.ExceptionInfo e#
+           (if (not= 401 (:response-code (ex-data e#)))
+             (throw e#)
+             (do
+               (println "Freesound token has expired, refreshing.")
+               (refresh-token!)
+               (try
+                 (do-request#)
+                 (catch clojure.lang.ExceptionInfo e#
+                   (if (not= 401 (:response-code (ex-data e#)))
+                     (throw e#)
+                     (do
+                       (println "Refresh didn't help, asking for a new token.")
+                       (reset! *access-token* nil)
+                       (do-request#))))))))))))
 
 ;; ## Sound Info
 (defn- info-url

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -9,7 +9,6 @@
   (is (= [0 2 4 5 7 9 11 12] (map sut/nth-interval (range 8))))
   (is (= [0 -1 -3 -5 -7 -8 -10 -12] (map sut/nth-interval (range 0 -8 -1)))))
 
-
 (deftest mk-midi-string
   (is (= "F7" (sut/mk-midi-string :F 7)))
   (is (= "Fb7" (sut/mk-midi-string :Fb 7)))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -238,10 +238,17 @@
 
 (deftest find-note-name-test
   (is (= :C4 (sut/find-note-name :B#4)))
-  (is (= :C-1 (sut/find-note-name :B#-1)))
-  (is (= :C#-1 (sut/find-note-name :Db-1)))
-  (is (= :B4 (sut/find-note-name :Cb4)))
+  (is (= :C-1
+         (sut/find-note-name 0)
+         (sut/find-note-name :B#-1)))
+  (is (= :C#-1
+         (sut/find-note-name 1)
+         (sut/find-note-name :Db-1)))
+  (is (= :B4
+         (sut/find-note-name 71)
+         (sut/find-note-name :Cb4)))
   (is (= :C4
+         (sut/find-note-name 60)
          (sut/find-note-name :C)
          (sut/find-note-name :C4)
          (sut/find-note-name :B#4))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -52,20 +52,19 @@
     (doseq [invalid [128 :B9]]
       (testing (pr-str invalid)
         (is (thrown? Exception (sut/note-info invalid))))))
-  (is (thrown? Exception (sut/note-info -1)))
-  (is (thrown? Exception (sut/note-info 128)))
   (doseq [invalid [-1 128
                    :C-2 :C10 :C#100]]
     (testing (pr-str invalid)
       (is (thrown? Exception (sut/note-info invalid)))))
   (is (= {:match "E#4", :pitch-class :F, :interval 5, :octave 4, :midi-note 65}
          (sut/note-info :E#4)))
-  (sut/note-info :Bb4)
-  (sut/note-info :Cb4)
-  (is (= {:match "B#4", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
-         (sut/note-info :B#4)))
   (is (= {:match "B4", :pitch-class :B, :interval 11, :octave 4, :midi-note 71}
-         (sut/note-info :B4))))
+         (sut/note-info :B4)))
+  (testing "middle C's"
+    (is (= {:match "B#4", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
+           (sut/note-info :B#4)))
+    (is (= {:match "C4", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
+           (sut/note-info :C4)))))
 
 (deftest find-scale-name-test
   (is (#{:melodic-minor :melodic-minor-asc} (sut/find-scale-name [2 1 2 2 2 2 1]))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -123,7 +123,6 @@
     (is (thrown? Exception (doall (sut/scale :c4 :major [-200]))))
     (is (thrown? Exception (doall (sut/scale :c4 :major [200]))))
     (is (thrown? Exception (doall (sut/scale 127 :major)))))
-
   (testing "abbreviations"
     (is (= (sut/scale)
            (sut/scale :major)
@@ -145,6 +144,21 @@
         (is (= (sut/scale 50 scale-name)
                (sut/scale :D3 scale-name)
                (sut/scale :D3 scale-name (range (inc (count (sut/resolve-scale scale-name)))))))))))
+
+(deftest rand-chord-test
+  (sut/rand-chord)
+  (sut/rand-chord :d)
+  (sut/rand-chord :d :major)
+  (sut/rand-chord :d :major 100)
+  (sut/rand-chord :d :major 100)
+  (sut/rand-chord 'd)
+  (sut/rand-chord 'e)
+  (sut/rand-chord 'e4)
+  (sut/rand-chord 'e-1)
+  (sut/rand-chord 'c-1)
+  ;;FIXME
+  (sut/rand-chord 'g9)
+  )
 
 (deftest degree->int-test
   )

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -31,10 +31,18 @@
   (is (= (sut/chord :F3 :major 1) '(57 60 65)))
   (is (= (sut/chord :F3 :major 2) '(60 65 69))))
 
+(deftest octave-of-test
+  (is (= -1 (sut/octave-of 0)))
+  (is (= 9 (sut/octave-of 127)))
+  (is (= 4 (sut/octave-of :C)))
+  (is (= 4 (sut/octave-of :B)))
+  (is (= 8 (sut/octave-of :C8))))
+
 (deftest octave-note-test
   (testing "octave too low"
     (is (thrown? Exception (sut/octave-note -2 0))))
   (is (= 0 (sut/octave-note -1 0)))
+  (is (= 0 (sut/octave-note :C-1 0)))
   (is (= 12 (sut/octave-note 0 0)))
   (testing "interval too high"
     (is (thrown? Exception (sut/octave-note 0 12))))
@@ -47,6 +55,8 @@
     (is (thrown? Exception (sut/octave-note 9 8))))
   (testing "octave too high"
     (is (thrown? Exception (sut/octave-note 10 0)))))
+
+(sut/octave :C-1)
 
 (deftest note-info-test
   ;; https://en.wikipedia.org/wiki/Scientific_pitch_notation
@@ -162,6 +172,18 @@
 
 (deftest degree->int-test
   )
+
+(deftest resolve-chord-notes-test
+  (is (= [60 64 67]
+         (sut/resolve-chord-notes [:C :E :G])
+         (sut/resolve-chord-notes [:C4 :E :G])
+         (sut/resolve-chord-notes [:C4 :E :G])
+         (sut/resolve-chord-notes [:C4 :E4 :G4])))
+  (is (= [64 67 72]
+         (sut/resolve-chord-notes [:E :G :C])
+         (sut/resolve-chord-notes [:E4 :G :C])
+         (sut/resolve-chord-notes [:E4 :G :C5])
+         (sut/resolve-chord-notes [:E4 :G4 :C5]))))
 
 (deftest scale-field-test
   (is (= 0 (first (sut/scale-field :c))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -93,6 +93,7 @@
   (is (= [60 61 62 63 64 65 66 67 68 69 70 71 72] (sut/scale :c4 :chromatic (range 1 13))))
   (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [2 4 7]))))
   (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [200]))))
+  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale 127 :major))))
   (is (= [60 62 63 65 67 68 70 72] (sut/scale :c4 :minor))))
 
 (deftest degree->int-test

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -1,12 +1,95 @@
 (ns overtone.music.pitch-test
-  (:use overtone.music.pitch
-        clojure.test))
+  (:require [clojure.test :refer [deftest is testing]]
+            [overtone.music.pitch :as sut]))
 
 (deftest invert-chord-works-properly
   (let [notes '(12 16 19 23)]
-    (is (= (invert-chord notes 2) '(19 23 24 28)))
-    (is (= (invert-chord notes -3) '(4 7 11 12)))))
+    (is (= (sut/invert-chord notes 2) '(19 23 24 28)))
+    (is (= (sut/invert-chord notes -3) '(4 7 11 12)))))
 
 (deftest chord-inversion-is-correct
-  (is (= (chord :F3 :major 1) '(57 60 65)))
-  (is (= (chord :F3 :major 2) '(60 65 69))))
+  (is (= (sut/chord :F3 :major 1) '(57 60 65)))
+  (is (= (sut/chord :F3 :major 2) '(60 65 69))))
+
+(deftest octave-note-test
+  (testing "octave too low"
+    (is (thrown? Exception (sut/octave-note -2 0))))
+  (is (= 0 (sut/octave-note -1 0)))
+  (is (= 12 (sut/octave-note 0 0)))
+  (testing "interval too high"
+    (is (thrown? Exception (sut/octave-note 0 12))))
+  (is (= sut/MIDDLE-C (sut/octave-note 4 0)))
+  (is (= 71 (sut/octave-note 4 11)))
+  (is (= (sut/octave-note 5 0)
+         (inc (sut/octave-note 4 11))))
+  (is (= 127 (sut/octave-note 9 7)))
+  (testing "highest octave has only 7 intervals"
+    (is (thrown? Exception (sut/octave-note 9 8))))
+  (testing "octave too high"
+    (is (thrown? Exception (sut/octave-note 10 0)))))
+
+(deftest note-info-test
+  ;; https://en.wikipedia.org/wiki/Scientific_pitch_notation
+  ;; The octave number is tied to the alphabetic character used to describe the pitch,
+  ;; with the division between note letters ‘B’ and ‘C’, thus:
+  (testing (str "B-1 and all of its possible variants (Bdouble flat, B♭, B, B♯, Bdouble sharp)"
+                "would properly be designated as being in octave -1")
+    (is (thrown? Exception (sut/note-info :B#-2)))
+    (is (= {:match "B-1", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
+           (sut/note-info :B-1))))
+  (testing (str "C-1 and all of its possible variants (Cdouble flat, C♭, C, C♯, Cdouble sharp)"
+                "would properly be designated as being in octave -1")
+    (is (= {:match "C-1", :pitch-class :C, :interval 0, :octave -1, :midi-note 0}
+           (sut/note-info 0)
+           (sut/note-info :C-1)))
+    (is (= {:match "Cb-1", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
+           (sut/note-info :Cb-1))))
+  (testing "highest note number is 127"
+    (is (= {:match "G9", :pitch-class :G, :interval 7, :octave 9, :midi-note 127}
+           (sut/note-info 127)
+           (sut/note-info :G9)))
+    (sut/note-info :B9)
+    (doseq [invalid [128 :B9]]
+      (testing (pr-str invalid)
+        (is (thrown? Exception (sut/note-info invalid))))))
+  (is (thrown? Exception (sut/note-info -1)))
+  (is (thrown? Exception (sut/note-info 128)))
+  (doseq [invalid [-1 128
+                   :C-2 :C10 :C#100]]
+    (testing (pr-str invalid)
+      (is (thrown? Exception (sut/note-info invalid)))))
+  (is (= {:match "E#4", :pitch-class :F, :interval 5, :octave 4, :midi-note 65}
+         (sut/note-info :E#4)))
+  (sut/note-info :Bb4)
+  (sut/note-info :Cb4)
+  (is (= {:match "B#4", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
+         (sut/note-info :B#4)))
+  (is (= {:match "B4", :pitch-class :B, :interval 11, :octave 4, :midi-note 71}
+         (sut/note-info :B4))))
+
+(deftest find-scale-name-test
+  (is (#{:melodic-minor :melodic-minor-asc} (sut/find-scale-name [2 1 2 2 2 2 1]))))
+
+(deftest find-pitch-class-name-test
+  (is (= :D (sut/find-pitch-class-name 62)))
+  (is (= :D (sut/find-pitch-class-name 74)))
+  (is (= :Eb (sut/find-pitch-class-name 75)))
+  (is (= '(:D :Eb :E :F :F# :G :Ab :A :Bb :B :C :C#)
+         (map sut/find-pitch-class-name (range 50 (+ 50 12)))))
+  )
+
+(deftest SCALE-test
+  (doseq [[scale notes] sut/SCALE]
+    (testing (pr-str scale)
+      (is (= 12 (apply + notes))))))
+
+(deftest scale-test
+  (is (= [60 62 64 65 67 69 71 72] (sut/scale :c4 :major)))
+  (is (= [60 61 62 63 64 65 66 67] (sut/scale :c4 :chromatic)))
+  (is (= [60 61 62 63 64 65 66 67 68 69 70 71 72] (sut/scale :c4 :chromatic (range 1 13))))
+  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [2 4 7]))))
+  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [200]))))
+  (is (= [60 62 63 65 67 68 70 72] (sut/scale :c4 :minor))))
+
+(deftest degree->int-test
+  )

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -105,7 +105,11 @@
     (is (= {:match "B#4", :spelling "B#" :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
            (sut/note-info :B#4)))
     (is (= {:match "C4", :spelling "C", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
-           (sut/note-info :C4)))))
+           (sut/note-info :C4))))
+  (testing "double sharps"
+    ;;TODO
+    (is (sut/note-info "Cbb"))
+    ))
 
 (deftest find-scale-name-test
   (is (#{:melodic-minor :melodic-minor-asc} (sut/find-scale-name [2 1 2 2 2 2 1]))))
@@ -186,10 +190,6 @@
     (is (every? #(<= 0 % 24) (sut/rand-chord :c-1 :major 3))))
   ;;FIXME
   ;(sut/rand-chord 'g9)
-  )
-
-(deftest degree->int-test
-  ;;TODO
   )
 
 (deftest degree->interval-test

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -189,6 +189,15 @@
   )
 
 (deftest degree->int-test
+  ;;TODO
+  )
+
+(deftest degree->interval-test
+  (is (= 2 (sut/degree->interval :ii :major)))
+  (is (= 2 (sut/degree->interval :ii#b :major)))
+  (is (= 1 (sut/degree->interval :iib :major)))
+  (is (= -1 (sut/degree->interval :iibbb :major)))
+  (is (= 5 (sut/degree->interval :iii# :major)))
   )
 
 (deftest resolve-chord-notes-test

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -2,6 +2,20 @@
   (:require [clojure.test :refer [deftest is testing]]
             [overtone.music.pitch :as sut]))
 
+(deftest shift-test
+  (is (= [1 1 3 3] (sut/shift [0 1 2 3] [0 2] 1))))
+
+(deftest mk-midi-string
+  (is (= "F7" (sut/mk-midi-string :F 7)))
+  (is (= "Fb7" (sut/mk-midi-string :Fb 7)))
+  (is (= "Fb7" (sut/mk-midi-string :Fb3 7)))
+  (is (= "C7" (sut/mk-midi-string 0 7)))
+  (testing "invalid note"
+    (is (thrown? Exception (sut/mk-midi-string -1 -1))))
+  (testing "invalid octave"
+    (is (thrown? Exception (sut/mk-midi-string 0 -2)))
+    (is (thrown? Exception (sut/mk-midi-string 0 10)))))
+
 (deftest invert-chord-works-properly
   (let [notes '(12 16 19 23)]
     (is (= (sut/invert-chord notes 2) '(19 23 24 28)))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -98,3 +98,22 @@
 
 (deftest degree->int-test
   )
+
+(deftest scale-field-test
+  (is (= 0 (first (sut/scale-field :c))))
+  (is (= 127 (peek (sut/scale-field :c))))
+  (is (= 75 (count (sut/scale-field :c))))
+  (is (= (sut/scale-field :c)
+         (sut/scale-field :b#)
+         (sut/scale-field :c4)
+         (sut/scale-field :c9)
+         (sut/scale-field 0)
+         (sut/scale-field 12)
+         (sut/scale-field 120)))
+  (is (= 128 (count (sut/scale-field :C :chromatic))))
+  (is (apply = (map #(sut/scale-field % :chromatic) (range 128))))
+  (testing "fields contain valid MIDI notes"
+    (doseq [note (range 128)
+            field (sut/scale-field 120)]
+      (testing (pr-str note)
+        (is (<= 0 field 127))))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -54,9 +54,16 @@
   (testing "highest octave has only 7 intervals"
     (is (thrown? Exception (sut/octave-note 9 8))))
   (testing "octave too high"
-    (is (thrown? Exception (sut/octave-note 10 0)))))
-
-(sut/octave :C-1)
+    (is (thrown? Exception (sut/octave-note 10 0))))
+  (testing "overloading"
+    (is (= 60
+           (sut/octave-note :C)
+           (sut/octave-note 4)
+           (sut/octave-note :C :C)
+           (sut/octave-note :C 0)
+           (sut/octave-note :C4 :C)))
+    (is (= 64 (sut/octave-note :C4 :E)))
+    (is (= 77 (sut/octave-note :D5 :E#)))))
 
 (deftest note-info-test
   ;; https://en.wikipedia.org/wiki/Scientific_pitch_notation
@@ -66,22 +73,22 @@
                 "would properly be designated as being in octave -1")
     (testing "B#-2 is not C-1"
       (is (thrown? Exception (sut/note-info :B#-2))))
-    (is (= {:match "B-1", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
+    (is (= {:match "B-1", :spelling "B" :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
            (sut/note-info :B-1))))
   (testing (str "C-1 and all of its possible variants (Cdouble flat, C♭, C, C♯, Cdouble sharp)"
                 "would properly be designated as being in octave -1")
-    (is (= {:match "C-1", :pitch-class :C, :interval 0, :octave -1, :midi-note 0}
+    (is (= {:match "C-1", :spelling "C", :pitch-class :C, :interval 0, :octave -1, :midi-note 0}
            (sut/note-info 0)
            (sut/note-info :C-1)))
     (testing "Cb-1 is not B-2"
-      (is (= {:match "Cb-1", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
+      (is (= {:match "Cb-1", :spelling "Cb", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
              (sut/note-info :Cb-1)))))
   (testing "notes numbers are between 0 and 127"
-    (is (= {:match "G9", :pitch-class :G, :interval 7, :octave 9, :midi-note 127}
+    (is (= {:match "G9", :spelling "G", :pitch-class :G, :interval 7, :octave 9, :midi-note 127}
            (sut/note-info 127)
            (sut/note-info :G9)))
     (testing "B#9 is C9"
-      (is (= {:match "B#9", :pitch-class :C, :interval 0, :octave 9, :midi-note 120}
+      (is (= {:match "B#9", :spelling "B#" :pitch-class :C, :interval 0, :octave 9, :midi-note 120}
              (sut/note-info :B#9))))
     (doseq [invalid [-1 128 :G#9 :Ab9 :A9 :A#9 :Bb9 :B9]]
       (testing (pr-str invalid)
@@ -90,14 +97,14 @@
     (doseq [invalid [:C-2 :C10 :C#100]]
       (testing (pr-str invalid)
         (is (thrown? Exception (sut/note-info invalid))))))
-  (is (= {:match "E#4", :pitch-class :F, :interval 5, :octave 4, :midi-note 65}
+  (is (= {:match "E#4", :spelling "E#" :pitch-class :F, :interval 5, :octave 4, :midi-note 65}
          (sut/note-info :E#4)))
-  (is (= {:match "B4", :pitch-class :B, :interval 11, :octave 4, :midi-note 71}
+  (is (= {:match "B4", :spelling "B" :pitch-class :B, :interval 11, :octave 4, :midi-note 71}
          (sut/note-info :B4)))
   (testing "middle C's"
-    (is (= {:match "B#4", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
+    (is (= {:match "B#4", :spelling "B#" :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
            (sut/note-info :B#4)))
-    (is (= {:match "C4", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
+    (is (= {:match "C4", :spelling "C", :pitch-class :C, :interval 0, :octave 4, :midi-note 60}
            (sut/note-info :C4)))))
 
 (deftest find-scale-name-test
@@ -117,18 +124,29 @@
       (is (= 12 (apply + notes))))))
 
 (deftest scale-test
-  (is (= [60 62 64 65 67 69 71 72] (sut/scale :c4 :major)))
-  (is (= [60 62 64 65 67 69 71 72] (sut/scale :c4 :minor)))
+  (is (= [60 62 64 65 67 69 71 72]
+         (sut/scale :c :major)
+         (sut/scale :c4 :major)))
+  (is (= [60 62 63 65 67 68 70 72]
+         (sut/scale :c :minor)
+         (sut/scale :c4 :minor)))
   (testing "backwards scales"
-    (is (= [72 70 68 67 65 63 62 60] (sut/scale :c4 :minor (range 7 -1 -1)))))
+    (is (= [72 70 68 67 65 63 62 60]
+           (sut/scale :c :minor (range 7 -1 -1))
+           (sut/scale :c4 :minor (range 7 -1 -1)))))
   (testing "infinite scales"
     (is (= [60 62 63 65 67 68 70 72 70 68 67 65 63 62 60 60 62 63 65 67]
+           (take 20 (sut/scale :c :minor (cycle (concat (range 7) (range 7 -1 -1)))))
            (take 20 (sut/scale :c4 :minor (cycle (concat (range 7) (range 7 -1 -1))))))))
   (testing "negative degrees"
     (is (= [60 58 56 55 53 51 50 48 46 46 48 50 51 53 55 56 58 60 60 58]
+           (take 20 (sut/scale :c :minor (cycle (concat (range 0 -9 -1) (range -8 1)))))
            (take 20 (sut/scale :c4 :minor (cycle (concat (range 0 -9 -1) (range -8 1))))))))
+  (is (= [60 61 62 63 64 65 66 67 68 69 70 71 72] (sut/scale :c :chromatic)))
   (is (= [60 61 62 63 64 65 66 67 68 69 70 71 72] (sut/scale :c4 :chromatic)))
-  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [0 2 4 7]))))
+  (is (= [:C4 :E4 :G4 :C5]
+         (map sut/find-note-name (sut/scale :c :major [0 2 4 7]))
+         (map sut/find-note-name (sut/scale :c4 :major [0 2 4 7]))))
   (testing "out of bounds midi note"
     (is (thrown? Exception (doall (sut/scale :c4 :major [-200]))))
     (is (thrown? Exception (doall (sut/scale :c4 :major [200]))))
@@ -138,8 +156,10 @@
            (sut/scale :major)
            (sut/scale 60 :major)
            (sut/scale sut/MIDDLE-C :major)
+           (sut/scale :c :major)
            (sut/scale :C :major)
            (sut/scale :C4 :major)
+           (sut/scale :C :major (range 8))
            (sut/scale :C4 :major (range 8))))
     (doseq [scale-name (keys sut/SCALE)]
       (testing (pr-str scale-name)
@@ -156,18 +176,16 @@
                (sut/scale :D3 scale-name (range (inc (count (sut/resolve-scale scale-name)))))))))))
 
 (deftest rand-chord-test
-  (sut/rand-chord)
-  (sut/rand-chord :d)
-  (sut/rand-chord :d :major)
-  (sut/rand-chord :d :major 100)
-  (sut/rand-chord :d :major 100)
-  (sut/rand-chord 'd)
-  (sut/rand-chord 'e)
-  (sut/rand-chord 'e4)
-  (sut/rand-chord 'e-1)
-  (sut/rand-chord 'c-1)
+  (dotimes [_ 100]
+    (is (every? #{:C :E :G} (map sut/canonical-pitch-class-name (sut/rand-chord))))
+    (is (every? #{:D :F# :A} (map sut/canonical-pitch-class-name (sut/rand-chord :d))))
+    (is (every? #{:D :F# :A} (map sut/canonical-pitch-class-name (sut/rand-chord :d :major))))
+    (is (every? #{:D :F :A} (map sut/canonical-pitch-class-name (sut/rand-chord :d :minor))))
+    (is (= 5 (count (sut/rand-chord :d :major 5))))
+    (is (every? #(<= 0 % 24) (sut/rand-chord :c-1 :major)))
+    (is (every? #(<= 0 % 24) (sut/rand-chord :c-1 :major 3))))
   ;;FIXME
-  (sut/rand-chord 'g9)
+  ;(sut/rand-chord 'g9)
   )
 
 (deftest degree->int-test
@@ -186,6 +204,12 @@
          (sut/resolve-chord-notes [:E4 :G4 :C5])))
   (is (= [60 64 67 71 74 77] (sut/resolve-chord-notes [:C :E :G :B :D :F])))
   (is (= [60 52 55 59 60 62 65] (sut/resolve-chord-notes [:C :E3 :G :B 60 :D :F]))))
+
+(deftest find-chord-test
+  (is (= {:root :C :chord-type :major} (sut/find-chord [:C :E :G])))
+  ;; TODO C major..
+  (is (= {:root :E :chord-type :m+5} (sut/find-chord [:E :G :C])))
+  (is (= {:root :C :chord-type :major7} (sut/find-chord [:C :E :G :B]))))
 
 (deftest scale-field-test
   (is (= 0 (first (sut/scale-field :c))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -235,3 +235,13 @@
   (is (= :B (sut/canonical-pitch-class-name 11)))
   (is (= :C (sut/canonical-pitch-class-name 12)))
   (is (thrown? Exception (sut/canonical-pitch-class-name 128))))
+
+(deftest find-note-name-test
+  (is (= :C4 (sut/find-note-name :B#4)))
+  (is (= :C-1 (sut/find-note-name :B#-1)))
+  (is (= :C#-1 (sut/find-note-name :Db-1)))
+  (is (= :B4 (sut/find-note-name :Cb4)))
+  (is (= :C4
+         (sut/find-note-name :C)
+         (sut/find-note-name :C4)
+         (sut/find-note-name :B#4))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -5,6 +5,11 @@
 (deftest shift-test
   (is (= [1 1 3 3] (sut/shift [0 1 2 3] [0 2] 1))))
 
+(deftest nth-interval-test
+  (is (= [0 2 4 5 7 9 11 12] (map sut/nth-interval (range 8))))
+  (is (= [0 -1 -3 -5 -7 -8 -10 -12] (map sut/nth-interval (range 0 -8 -1)))))
+
+
 (deftest mk-midi-string
   (is (= "F7" (sut/mk-midi-string :F 7)))
   (is (= "Fb7" (sut/mk-midi-string :Fb 7)))
@@ -103,12 +108,43 @@
 
 (deftest scale-test
   (is (= [60 62 64 65 67 69 71 72] (sut/scale :c4 :major)))
-  (is (= [60 61 62 63 64 65 66 67] (sut/scale :c4 :chromatic)))
-  (is (= [60 61 62 63 64 65 66 67 68 69 70 71 72] (sut/scale :c4 :chromatic (range 1 13))))
-  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [2 4 7]))))
-  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [200]))))
-  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale 127 :major))))
-  (is (= [60 62 63 65 67 68 70 72] (sut/scale :c4 :minor))))
+  (is (= [60 62 64 65 67 69 71 72] (sut/scale :c4 :minor)))
+  (testing "backwards scales"
+    (is (= [72 70 68 67 65 63 62 60] (sut/scale :c4 :minor (range 7 -1 -1)))))
+  (testing "infinite scales"
+    (is (= [60 62 63 65 67 68 70 72 70 68 67 65 63 62 60 60 62 63 65 67]
+           (take 20 (sut/scale :c4 :minor (cycle (concat (range 7) (range 7 -1 -1))))))))
+  (testing "negative degrees"
+    (is (= [60 58 56 55 53 51 50 48 46 46 48 50 51 53 55 56 58 60 60 58]
+           (take 20 (sut/scale :c4 :minor (cycle (concat (range 0 -9 -1) (range -8 1))))))))
+  (is (= [60 61 62 63 64 65 66 67 68 69 70 71 72] (sut/scale :c4 :chromatic)))
+  (is (= [:C4 :E4 :G4 :C5] (map sut/find-note-name (sut/scale :c4 :major [0 2 4 7]))))
+  (testing "out of bounds midi note"
+    (is (thrown? Exception (doall (sut/scale :c4 :major [-200]))))
+    (is (thrown? Exception (doall (sut/scale :c4 :major [200]))))
+    (is (thrown? Exception (doall (sut/scale 127 :major)))))
+
+  (testing "abbreviations"
+    (is (= (sut/scale)
+           (sut/scale :major)
+           (sut/scale 60 :major)
+           (sut/scale sut/MIDDLE-C :major)
+           (sut/scale :C :major)
+           (sut/scale :C4 :major)
+           (sut/scale :C4 :major (range 8))))
+    (doseq [scale-name (keys sut/SCALE)]
+      (testing (pr-str scale-name)
+        (is (= (sut/scale scale-name)
+               (sut/scale 60 scale-name)
+               (sut/scale sut/MIDDLE-C scale-name)
+               (sut/scale :C scale-name)
+               (sut/scale :C4 scale-name)
+               (sut/scale :C4 scale-name (range (inc (count (sut/resolve-scale scale-name)))))))))
+    (doseq [scale-name (keys sut/SCALE)]
+      (testing (pr-str scale-name)
+        (is (= (sut/scale 50 scale-name)
+               (sut/scale :D3 scale-name)
+               (sut/scale :D3 scale-name (range (inc (count (sut/resolve-scale scale-name)))))))))))
 
 (deftest degree->int-test
   )

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -183,7 +183,9 @@
          (sut/resolve-chord-notes [:E :G :C])
          (sut/resolve-chord-notes [:E4 :G :C])
          (sut/resolve-chord-notes [:E4 :G :C5])
-         (sut/resolve-chord-notes [:E4 :G4 :C5]))))
+         (sut/resolve-chord-notes [:E4 :G4 :C5])))
+  (is (= [60 64 67 71 74 77] (sut/resolve-chord-notes [:C :E :G :B :D :F])))
+  (is (= [60 52 55 59 60 62 65] (sut/resolve-chord-notes [:C :E3 :G :B 60 :D :F]))))
 
 (deftest scale-field-test
   (is (= 0 (first (sut/scale-field :c))))
@@ -203,3 +205,9 @@
             field (sut/scale-field 120)]
       (testing (pr-str note)
         (is (<= 0 field 127))))))
+
+(deftest canonical-pitch-class-name-test
+  (is (= :C (sut/canonical-pitch-class-name 0)))
+  (is (= :B (sut/canonical-pitch-class-name 11)))
+  (is (= :C (sut/canonical-pitch-class-name 12)))
+  (is (thrown? Exception (sut/canonical-pitch-class-name 128))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -117,7 +117,11 @@
     (is (= {:match "Cbbbbbbbbbbbb", :spelling "Cbbbbbbbbbbbb", :pitch-class :C, :interval 0}
            (sut/note-info "Cbbbbbbbbbbbb")))
     (is (= {:match "Cbbbbbbbbbbbb-1", :spelling "Cbbbbbbbbbbbb", :pitch-class :C, :interval 0, :octave -1, :midi-note 0}
-           (sut/note-info "Cbbbbbbbbbbbb-1")))))
+           (sut/note-info "Cbbbbbbbbbbbb-1"))))
+  ;;FIXME https://en.wikipedia.org/wiki/Scientific_pitch_notation
+  (is (= (sut/note "Cb4")
+         (sut/note "B3")))
+  )
 
 (deftest find-scale-name-test
   (is (#{:melodic-minor :melodic-minor-asc} (sut/find-scale-name [2 1 2 2 2 2 1]))))

--- a/test/overtone/music/pitch_test.clj
+++ b/test/overtone/music/pitch_test.clj
@@ -8,6 +8,7 @@
     (is (= (sut/invert-chord notes -3) '(4 7 11 12)))))
 
 (deftest chord-inversion-is-correct
+  (is (= (sut/chord :F3 :major 0) '(53 57 60)))
   (is (= (sut/chord :F3 :major 1) '(57 60 65)))
   (is (= (sut/chord :F3 :major 2) '(60 65 69))))
 
@@ -34,7 +35,8 @@
   ;; with the division between note letters ‘B’ and ‘C’, thus:
   (testing (str "B-1 and all of its possible variants (Bdouble flat, B♭, B, B♯, Bdouble sharp)"
                 "would properly be designated as being in octave -1")
-    (is (thrown? Exception (sut/note-info :B#-2)))
+    (testing "B#-2 is not C-1"
+      (is (thrown? Exception (sut/note-info :B#-2))))
     (is (= {:match "B-1", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
            (sut/note-info :B-1))))
   (testing (str "C-1 and all of its possible variants (Cdouble flat, C♭, C, C♯, Cdouble sharp)"
@@ -42,20 +44,23 @@
     (is (= {:match "C-1", :pitch-class :C, :interval 0, :octave -1, :midi-note 0}
            (sut/note-info 0)
            (sut/note-info :C-1)))
-    (is (= {:match "Cb-1", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
-           (sut/note-info :Cb-1))))
-  (testing "highest note number is 127"
+    (testing "Cb-1 is not B-2"
+      (is (= {:match "Cb-1", :pitch-class :B, :interval 11, :octave -1, :midi-note 11}
+             (sut/note-info :Cb-1)))))
+  (testing "notes numbers are between 0 and 127"
     (is (= {:match "G9", :pitch-class :G, :interval 7, :octave 9, :midi-note 127}
            (sut/note-info 127)
            (sut/note-info :G9)))
-    (sut/note-info :B9)
-    (doseq [invalid [128 :B9]]
+    (testing "B#9 is C9"
+      (is (= {:match "B#9", :pitch-class :C, :interval 0, :octave 9, :midi-note 120}
+             (sut/note-info :B#9))))
+    (doseq [invalid [-1 128 :G#9 :Ab9 :A9 :A#9 :Bb9 :B9]]
       (testing (pr-str invalid)
         (is (thrown? Exception (sut/note-info invalid))))))
-  (doseq [invalid [-1 128
-                   :C-2 :C10 :C#100]]
-    (testing (pr-str invalid)
-      (is (thrown? Exception (sut/note-info invalid)))))
+  (testing "octaves are betwen -1 and 9"
+    (doseq [invalid [:C-2 :C10 :C#100]]
+      (testing (pr-str invalid)
+        (is (thrown? Exception (sut/note-info invalid))))))
   (is (= {:match "E#4", :pitch-class :F, :interval 5, :octave 4, :midi-note 65}
          (sut/note-info :E#4)))
   (is (= {:match "B4", :pitch-class :B, :interval 11, :octave 4, :midi-note 71}


### PR DESCRIPTION
Let me know if any of these look interesting and I can update the changelog.

TODO: I need to fix a misunderstanding I had: Cb4 and B4 are not enharmonic.

- support any combination of accidentals
- fix `scale` only playing 8 notes of a scale for scales longer/shorter than major/minor
  - now plays n+1 notes for scales with n degrees
  - technically a breaking change but should sound much better :)
- Breaking: 3-arity of `scale` is now much more flexible, can generate scales forwards/backwards/cycled/arpeggios/chords/inversions. The change is that the root is no longer automatically appended to the front of the scale.
- add new vars `{unison,fifth,fourth,...}-ratio`
- add range checking for midi notes (0-127) and octaves (-1-9)
  - don't check ranges for ported SC functions like midicps and cpsmidi
- add coercions and default arguments to most functions for greater expressivity
- add extensive test suite and documentation