### PR TITLE
Enable event `:beat` and `:start time`

### DIFF
--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -321,9 +321,16 @@
                            (pattern/pfirst pseq)
                            proto)
           dur       (eget e :dur)
-          type      (eget e :type)
           next-seq  (pattern/pnext pseq)
-          next-beat (+ beat dur)]
+          dur       (eget e :dur)
+          next-e    (pattern/pfirst next-seq)
+          next-start-beat (some-> next-e
+                                  (eget :start-time)
+                                  (- (rhythm/metro-start clock))
+                                  (/ (rhythm/metro-tick clock)))
+          next-beat (or next-start-beat
+                        (eget next-e :beat)
+                        (+ beat dur))]
       (if pseq
         (assoc player
                :pseq next-seq

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -415,13 +415,9 @@
                       pseq
                       opts]
   ;; TODO: this is not yet taking :offset into account
-  ;; FIXME: the clock restart leads to some weirdness when starting multiple
-  ;; loops at the same time
   (let [align (:align opts (:align player :quant))
         quant (:quant opts (:quant player 4))
         playing (some :playing (vals @pplayers))
-        _ (when-not playing
-            (clock :start 0))
         beat (if playing
                (max (or beat 1) (clock))
                (clock))


### PR DESCRIPTION
The pattern library docs claim support for setting `:start-time` or `:beat` on an event.

This change updates the `next-beat` calculation to include peeking at the next event to schedule it appropriately, falling back to `(+ beat dur)`.

The reset of the clock to 0 when no players are active causes problems. It is noted in `FIXME` about starting multiple players. In my case, since I'm setting event times based on the clock, resetting it wreaks havoc. I hope that going forward it makes sense for the pattern lib to take a read only approach to the clock. Who knows what else a client of the lib might be using their clock for?

I know you're in the middle of edits to pattern lib and I don't want to step on your toes, @plexus, but this is an issue I ran into.