### PR TITLE
Rename `binary-div-op` ugen var to `/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Fixed
 
 ## Changed
+- `overtone.sc.ugen-collide/binary-div-op` ugen has been renamed `overtone.sc.ugen-collide//`
+  - no change under `with-overloaded-ugens`
 
 # 0.15.3295 (2024-10-24 / d354b4f)
 

--- a/src/overtone/sc/machinery/ugen/fn_gen.clj
+++ b/src/overtone/sc/machinery/ugen/fn_gen.clj
@@ -288,7 +288,7 @@
   with-overloaded-ugens"
   [src-ns target-ns ugen-name ugen-fn kind]
   (let [original-fn   (ns-resolve src-ns ugen-name)
-        overload-name (if (= '/ ugen-name) 'binary-div-op ugen-name)
+        overload-name ugen-name
         ugen-name-str (str ugen-name)
         overloaded-fn (case kind
                         :unary (mk-overloaded-ugen-fn ugen-name-str ugen-fn)

--- a/test/overtone/sc/ugen_collide_test.clj
+++ b/test/overtone/sc/ugen_collide_test.clj
@@ -1,6 +1,7 @@
 (ns overtone.sc.ugen-collide-test
   (:require [clojure.test :refer [deftest is testing]]
             [overtone.sc.ugens :as u :refer [gate:kr]]
+            [overtone.sc.ugen-collide :as sut]
             [overtone.sc.machinery.ugen.sc-ugen :as urep]))
 
 ;; there used to be ugens called and/or (originally sig-{and,or,xor}).
@@ -51,3 +52,9 @@
     (is (= 1 (u/with-overloaded-ugens (bit-xor 1 2 3 4 5))))
     (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-xor 1 2 (gate:kr) 4 5))))
     (is (urep/sc-ugen? (u/with-overloaded-ugens (bit-xor 1 2 (gate:kr) 4 5 :force-ugen))))))
+
+(deftest divide-test
+  (is (= 5/2 (u/with-overloaded-ugens (/ 5 2))))
+  (is (urep/sc-ugen? (u/with-overloaded-ugens (/ 5 2 :force-ugen))))
+  (is (= 5/2 (sut// 5 2)))
+  (is (urep/sc-ugen? (sut// 5 2 :force-ugen))))


### PR DESCRIPTION
Sometime in the last 10+ years Clojure explicitly supported vars called `/`. `with-overloaded-ugen` wraps with `(let [/ binary-div-op] ..)`, so most users will not notice this.