### PR TITLE
Window compat: rename overtone.studio.aux => overtone.studio.aux-bus

### DIFF
--- a/src/overtone/api.clj
+++ b/src/overtone/api.clj
@@ -21,7 +21,7 @@
    (overtone.sc.cgens oscillators demand mix dyn io buf-io env tap
                       line freq beq-suite berlach ;; bhob
                       fx info)
-   (overtone.studio aux mixer inst util fx wavetable midi midi-player core
+   (overtone.studio aux-bus mixer inst util fx wavetable midi midi-player core
                     pattern event)))
 
 
@@ -106,7 +106,7 @@
    'overtone.sc.ugens
    'overtone.sc.vbap
    'overtone.speech
-   'overtone.studio.aux
+   'overtone.studio.aux-bus
    'overtone.studio.core
    'overtone.studio.fx
    'overtone.studio.inst

--- a/src/overtone/studio/aux_bus.clj
+++ b/src/overtone/studio/aux_bus.clj
@@ -1,4 +1,4 @@
-(ns overtone.studio.aux
+(ns overtone.studio.aux-bus
   "Model the concept of an AUX bus, as found on analog mixing consoles. From each
   instrument you can 'send' some of the signal to the AUX bus, forming a
   separate mix.


### PR DESCRIPTION
Close #561

Cannot have a file named aux.clj on Windows.

https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions


> Do not use the following reserved names for the name of a file:
> 
> CON, PRN, **AUX**, NUL, COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, COM¹, COM², COM³, LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9, LPT¹, LPT², and LPT³.
> 
> **Also avoid these names followed immediately by an extension**; for example, NUL.txt and NUL.tar.gz are both equivalent to NUL. For more information, see [Namespaces](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces).