### PR TITLE
Make stringed helpers work with `at`

### DIFF
--- a/src/overtone/osc/dyn_vars.clj
+++ b/src/overtone/osc/dyn_vars.clj
@@ -3,3 +3,7 @@
 ;; We use binding to *osc-msg-bundle* to bundle messages
 ;; and send combined with an OSC timestamp.
 (defonce ^{:dynamic true} *osc-msg-bundle* nil)
+
+;; Timestamp of currently building `at` message bundle, if any.
+;; Used by `at-offset` to schedule messages relative an enclosing `at`.
+(defonce ^{:dynamic true} *at-time* nil)


### PR DESCRIPTION
- Added `at-offset`, including new dynamic var to hold scheduled time of enclosing `at`, if any.
- `pluck-string`, `strum-string`, and `slide-string` now work correctly with `at`. 
- Arities that take a start time are retained to avoid breaking change.
- Eliminated `now+`, a function that scheduled immediate stringed instrument events 21ms in the future. 
 
Note, the issue that `now+` was dealing with remains - scheduling events too soon results in late warnings. The new `at-offset` checks for events that are <=20ms from now and sends them immediately, with no scheduling, to avoid the warning. `at-offset` is a more appropriate place to deal with that situation than a one-off adjustment in the `stringed` namespace. I would appreciate any feedback or alternative ideas.