### PR TITLE
Fix double-eval for `overtone.sc.server/at{-offset}` macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#557](https://github.com/overtone/overtone/issues/557): envelope description array generators have line numbers for jump-to-definition purposes
 
+- fix double-eval for `overtone.sc.server/at{-offset}` macros
 
 ## Changed
 - `overtone.sc.ugen-collide/binary-div-op` ugen has been renamed `overtone.sc.ugen-collide//`

--- a/test/overtone/sc/server_test.clj
+++ b/test/overtone/sc/server_test.clj
@@ -1,0 +1,14 @@
+(ns overtone.sc.server-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [overtone.sc.server :as sut]
+            [overtone.test-helper :as th]))
+
+(use-fixtures :once th/ensure-server)
+
+(deftest double-eval-test
+  (let [a (atom 0)]
+    (sut/at (swap! a inc))
+    (is (= 1 @a)))
+  (let [a (atom 0)]
+    (sut/at-offset (swap! a inc))
+    (is (= 1 @a))))

--- a/test/overtone/test_helper.clj
+++ b/test/overtone/test_helper.clj
@@ -2,7 +2,8 @@
   "Helpful functions and macro's for writing Overtone tests."
   (:require [overtone.libs.event :refer [sync-event]]
             [overtone.sc.machinery.server.comms :as comms]
-            [overtone.sc.server :as server])
+            [overtone.sc.server :as server]
+            [overtone.studio.mixer :as mixer])
   (:import [java.util.concurrent TimeoutException]))
 
 ;; ns helpers
@@ -82,7 +83,7 @@
 
 (defn ensure-server [f]
   (when-not (server/server-connected?)
-    (server/boot-server))
+    (mixer/boot-server-and-mixer))
   (f))
 
 (def with-server-sync #'comms/with-server-sync)


### PR DESCRIPTION
Also reduced the number of dynamic var derefs.