### PR TITLE
Add `overtone.sc.sclang` ns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    branches: [master, main]
 
 jobs:
   build:
@@ -44,18 +43,18 @@ jobs:
           cli: latest
 
       - name: Windows dependencies
-        uses: actions/checkout@v4
-        with:
-          path: sonic-pi
-          repository: 'sonic-pi-net/sonic-pi'
-          sparse-checkout: |
-            prebuilt/windows/${{matrix.arch}}
+        shell: bash
+        run: |
+          mkdir ../sc-install
+          cd ../sc-install
+          curl -L -o ./SuperCollider.zip https://github.com/supercollider/supercollider/releases/download/Version-3.13.0/SuperCollider-3.13.0-win64.zip
+          unzip SuperCollider.zip
         if: matrix.os == 'windows-latest'
 
-      - name: Add scsynth.exe to PATH on Windows
+      - name: Add sc{synth,lang}.exe to PATH on Windows
         shell: powershell
         run: |
-          Add-Content $env:GITHUB_PATH "${{github.workspace}}\sonic-pi\prebuilt\windows\${{matrix.arch}}"
+          Add-Content $env:GITHUB_PATH "${{github.workspace}}\..\sc-install\SuperCollider"
         if: matrix.os == 'windows-latest'
 
       - name: Mac dependencies
@@ -63,21 +62,6 @@ jobs:
           export HOMEBREW_NO_INSTALL_CLEANUP=1
           brew update
           brew install supercollider
-        if: matrix.os == 'macos-latest'
-
-      - name: Mac dependencies
-        with:
-          path: sonic-pi
-          repository: 'sonic-pi-net/sonic-pi'
-          sparse-checkout: |
-            prebuilt/macos/universal/supercollider
-        uses: actions/checkout@v4
-        if: matrix.os == 'macos-latest'
-
-      - name: Add scsynth to PATH on macOS
-        run: |
-          echo "${{github.workspace}}/sonic-pi/prebuilt/macos/universal/supercollider/Resources" >> $GITHUB_PATH
-          echo "${{github.workspace}}/sonic-pi/prebuilt/macos/universal/supercollider/Frameworks" >> $GITHUB_PATH
         if: matrix.os == 'macos-latest'
 
       - name: Grant microphone access for macos
@@ -89,7 +73,7 @@ jobs:
 
       - name: Linux dependencies
         run: |
-          sudo apt-get install -y pulseaudio dbus-x11 libssl-dev supercollider-server sc3-plugins-server alsa-base alsa-utils jackd2 libjack-jackd2-dev libjack-jackd2-0 libasound2-dev librtmidi-dev pulseaudio-module-jack
+          sudo apt-get install -y pulseaudio dbus-x11 libssl-dev supercollider-language supercollider-server sc3-plugins-server alsa-base alsa-utils jackd2 libjack-jackd2-dev libjack-jackd2-0 libasound2-dev librtmidi-dev pulseaudio-module-jack
         if: matrix.os == 'ubuntu-latest'
 
       - name: Overtone tests - Mac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   and to use `sclang` generated synthdefs
   - Even if the final user doesn't have  `sclang` available on their machine,
     as long as the resource was generated previously, it should work transparently
+- Add `:sclang-path` config to set `sclang` executable location
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## Added
 
-- Add `overtone.sc.sclang` namespace to interact with the `sclang` commands
-  and to use `sclang` generated synthdefs
-  - Even if the final user doesn't have  `sclang` available on their machine,
-    as long as the resource was generated previously, it should work transparently
-- Add `:sclang-path` config to set `sclang` executable location
+- [567](https://github.com/overtone/overtone/pull/567)
+  - Add `overtone.sc.sclang` namespace to interact with the `sclang` commands
+    and to use `sclang` generated synthdefs
+    - Even if the final user doesn't have  `sclang` available on their machine,
+      as long as the resource was generated previously, it should work transparently
+  - Add `:sclang-path` config to set `sclang` executable location
 
 ## Fixed
+
+- [567](https://github.com/overtone/overtone/pull/567)
+  - `resources` directory is included in Overtone's jar and deps.edn path (adds `overtone-logo.png` back to class path)
 
 - [#556](https://github.com/overtone/overtone/issues/556)
   - multichannel expanding logic for ugens now correctly handles keyword arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Added
 
+- Add `overtone.sc.sclang` namespace to interact with the `sclang` commands
+  and to use `sclang` generated synthdefs
+  - Even if the final user doesn't have  `sclang` available on their machine,
+    as long as the resource was generated previously, it should work transparently
+
 ## Fixed
 
 - [#556](https://github.com/overtone/overtone/issues/556)
@@ -140,7 +145,7 @@ reconcile the two.
 
 This is the first version without the internal SuperCollider server
 (libscsynth). See [this mailing list post](https://groups.google.com/g/overtone/c/qndjDV5FS9Y/m/lPo4QFYpAAAJ)
-for the reasoning behind that change. This also means we could drop the bulk of our dependencies, 
+for the reasoning behind that change. This also means we could drop the bulk of our dependencies,
 making Overtone much lighter.
 
 Our work continues to keep Overtone relevant for years to come. We've fixed a
@@ -153,7 +158,7 @@ wiki, to help you get situated.
 
 ## Changed
 
-- Remove embedded (internal) SuperCollider server 
+- Remove embedded (internal) SuperCollider server
 - Provide clearer output about what it's doing when starting an external `scsynth`
 - Remove `project.clj`, switch to full Clojure CLI based tooling (see `bin/proj`)
 - Use `at-at` from Clojars, rather than inlining it here
@@ -196,7 +201,7 @@ and keeping it relevant for years to come.
 * use canonical URL for freesound API (#479)
 * Fix window paths to allow downloading samples (#487)
 * Removed obsolete JVM option CMSConcurrentMTEnabled (#488)
-* Read synthdef files correctly (#489) 
+* Read synthdef files correctly (#489)
 * Fix buffer reading (#490)
 * Add clj-kondo support (see `overtone.linter`) (#493)
 * Qualify the overtone ns in lein example (#495)

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
 
  :deps
  {overtone/at-at          {:mvn/version "1.4.65"}
@@ -6,7 +6,11 @@
   commons-net/commons-net {:mvn/version "3.10.0"} ; Decode OSC timetag
   javax.jmdns/jmdns       {:mvn/version "3.4.1"}  ; ZeroConf support
   clj-glob/clj-glob       {:mvn/version "1.0.0"} ; overtone.helpers.file/{glob,ls*}
-  casa.squid/jack         {:mvn/version "0.2.12"}}
+  casa.squid/jack         {:mvn/version "0.2.12"}
+
+  ;; For processes, it supports Windows well and it has some niceties that
+  ;; clojure.java.shell doesn't have.
+  babashka/process {:mvn/version "0.5.22"}}
 
  :aliases
  {:test

--- a/docs/config.clj
+++ b/docs/config.clj
@@ -27,6 +27,7 @@
                     ;          diagnostic information
 
  :sc-path "/usr/bin/scsynth" ; Where to find the SuperCollider server executable
+ :sclang-path "/usr/bin/sclang" ; Where to find the SuperCollider language executable
 
  :sc-args           ; Argument map used to boot the SuperCollider server
                     ; with the following arguments:

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,9 @@
       <resource>
         <directory>src</directory>
       </resource>
+      <resource>
+        <directory>resources</directory>
+      </resource>
     </resources>
     <plugins>
       <plugin>

--- a/src/overtone/helpers/file.clj
+++ b/src/overtone/helpers/file.clj
@@ -5,7 +5,8 @@
    [clojure.java.io :refer :all]
    [clojure.string :as str]
    [org.satta.glob :as satta-glob]
-   [overtone.helpers.string :refer :all])
+   [overtone.helpers.string :refer :all]
+   [overtone.helpers.system :refer [get-os]])
   (:import
    (java.io StringWriter)
    (java.net URL)
@@ -507,3 +508,10 @@
        (when (file-can-execute? f)
          f)))
    (.split (System/getenv "PATH") java.io.File/pathSeparator)))
+
+(defn find-well-known-sc-path
+  "Find the path for SuperCollider by checking common locations."
+  [default-paths]
+  (let [os    (get-os)
+        paths (get default-paths os)]
+    (first (filter #(file-can-execute? %) paths))))

--- a/src/overtone/sc/defaults.clj
+++ b/src/overtone/sc/defaults.clj
@@ -62,4 +62,11 @@
           "/Applications/SuperCollider.app/Contents/Resources/scsynth"
           "/Applications/SuperCollider/SuperCollider.app/Contents/Resources/scsynth"]})
 
+(def SCLANG-PATHS
+  "Default system paths to an externally installed SuperCollider server for
+  various operating systems."
+  {:linux ["/usr/bin/sclang"]
+   :windows [(str (windows-sc-path) "\\sclang.exe")]
+   :mac  ["/Applications/SuperCollider.app/Contents/MacOS/sclang"]})
+
 (def SC-MAX-FLOAT-VAL (Math/pow 2 24))

--- a/src/overtone/sc/machinery/server/connection.clj
+++ b/src/overtone/sc/machinery/server/connection.clj
@@ -229,13 +229,6 @@
        (Thread/sleep 250))
      (.destroy ^Process proc))))
 
-(defn- find-well-known-sc-path
-  "Find the path for SuperCollider by checking common locations."
-  []
-  (let [os    (get-os)
-        paths (defaults/SC-PATHS os)]
-    (first (filter #(file/file-can-execute? %) paths))))
-
 (defn- find-sc-arg-flag!
   "Retrieves the SC argument flag for sc-arg. Throws exception if flag
    can't be found."
@@ -279,7 +272,7 @@
                              (file/find-executable "scsynth.exe"))
                            ;; should windows look here?
                            (file/find-executable "scsynth")))
-        sc-wellknown (delay (find-well-known-sc-path))
+        sc-wellknown (delay (file/find-well-known-sc-path defaults/SC-PATHS))
         match (or sc-config @sc-path @sc-wellknown)]
     (when-not match
       (throw (ex-info (str "Failed to find SuperCollider server executable (scsynth). The file does not exist or is not executable. Places I've looked:\n"

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -8,23 +8,26 @@
    [overtone.sc.machinery.server.connection :as ov.conn]
    [overtone.sc.synth :as ov.synth]))
 
+(defonce *sclang-user-path (atom nil))
+
 (defn sclang-path
   "The user must have SuperCollider installed.
 
   For sclang location in each OS, see
   https://github.com/supercollider/supercollider/wiki/Path-searching#scide-finds-sclang"
   []
-  (cond
-    (mac-os?)
-    "/Applications/SuperCollider.app/Contents/MacOS/sclang"
-    ;; It's simply `sclang` in non OSX environments,
-    ;; https://github.com/supercollider/supercollider/wiki/Path-searching#scide-finds-sclang
-    ;; TODO Someone should test on Linux and Windows to confirm that this works.
-    (windows-os?)
-    "sclang.exe"
+  (or @*sclang-user-path
+      (cond
+        (mac-os?)
+        "/Applications/SuperCollider.app/Contents/MacOS/sclang"
+        ;; It's simply `sclang` in non OSX environments,
+        ;; https://github.com/supercollider/supercollider/wiki/Path-searching#scide-finds-sclang
+        ;; TODO Someone should test on Linux and Windows to confirm that this works.
+        (windows-os?)
+        "sclang.exe"
 
-    :else
-    "sclang"))
+        :else
+        "sclang")))
 
 (defn transpile
   "Converts hiccup-like syntax to a SC string."
@@ -353,6 +356,9 @@
   for caching. As long you distribute the generated .scsyndef file in the right location and you don't
   modify `sc-clj`, the final user won't need to have `sclang` or SuperCollider installed
   on their machines.
+
+  Check `sclang-path` code for the default locations. You can also set the
+  `*sclang-user-path` atom to use an arbitrary `sclang` location.
 
   --------------------
   ;; Example.

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -1,0 +1,395 @@
+(ns overtone.sc.sclang
+  (:require
+   [babashka.process :as proc]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [overtone.helpers.system :refer [get-os linux-os? mac-os? windows-os?]]
+   [overtone.sc.machinery.server.connection :as ov.conn]
+   [overtone.sc.synth :as ov.synth]))
+
+(defn sclang-path
+  "The user must have SuperCollider installed.
+
+  For sclang location in each OS, see
+  https://github.com/supercollider/supercollider/wiki/Path-searching#scide-finds-sclang"
+  []
+  (cond
+    (mac-os?)
+    "/Applications/SuperCollider.app/Contents/MacOS/sclang"
+    ;; It's simply `sclang` in non OSX environments,
+    ;; https://github.com/supercollider/supercollider/wiki/Path-searching#scide-finds-sclang
+    ;; TODO Someone should test on Linux and Windows to confirm that this works.
+    (windows-os?)
+    "sclang.exe"
+
+    :else
+    "sclang"))
+
+(defn transpile
+  "Converts hiccup-like syntax to a SC string."
+  [sc-clj]
+  (let [[op & body] (if (sequential? sc-clj)
+                      sc-clj
+                      [sc-clj])]
+    (try
+      (cond
+        (and (= op :SynthDef) (sequential? sc-clj))
+        (let [{:keys [args resources-dir]
+               :or {resources-dir "resources"}
+               synthdef-name :name}
+              (first body)
+
+              synthdef-name (-> synthdef-name
+                                (str/replace #"\." "_")
+                                (str/replace #"/" "_"))
+
+              resource-prefix "sc/synthdef"
+              file-dir (str resources-dir "/" resource-prefix)
+
+              file-path (str file-dir "/" synthdef-name ".scsyndef")
+              resource-path (str resource-prefix "/" synthdef-name ".scsyndef")
+
+              metadata-file-path (str file-dir "/" synthdef-name ".edn")
+              metadata-resource-path (str resource-prefix "/" synthdef-name ".edn")
+
+              body (rest body)
+              synthdef-str (str "SynthDef"
+                                "(" (str "\"" synthdef-name "\"" ",") " {\n"
+                                (->> [(str "arg "
+                                           (->> args
+                                                (mapv (fn [[arg-identifier default]]
+                                                        (str (name arg-identifier) "=" default)))
+                                                (str/join ", "))
+                                           ";")
+
+                                      (->> body
+                                           (mapv (fn [row]
+                                                   (str (transpile row) ";")))
+                                           (str/join "\n  "))]
+                                     (mapv #(str "  " %))
+                                     (str/join "\n"))
+                                (format "\n}).writeDefFile(\"%s\").add;"
+                                        file-dir))]
+          {:sc-clj sc-clj
+           :synthdef-name synthdef-name
+           :file-path file-path
+           :resource-path resource-path
+           :metadata-file-path metadata-file-path
+           :metadata-resource-path metadata-resource-path
+           :synthdef-str synthdef-str
+           ;; This one is to ease debugging.
+           :synthdef-str-vec (str/split-lines synthdef-str)})
+
+        (contains? #{:* :=} op)
+        (->> body
+             (mapv transpile)
+             (str/join (str " " (name op) " ")))
+
+        (contains? #{:.} op)
+        (->> body
+             (mapv transpile)
+             (str/join (name op)))
+
+        (= :vars op)
+        (str "var "
+             (->> body
+                  (mapv (fn [var-identifier]
+                          (name var-identifier)))
+                  (str/join ", ")))
+
+        (and (keyword? op) body)
+        (str (name op)
+             "( "
+             (->> body
+                  (mapv transpile)
+                  (str/join ", "))
+             " )")
+
+        (and (or (keyword? op)
+                 (symbol? op))
+             (not body))
+        (name op)
+
+        (sequential? sc-clj)
+        (str "["
+             (->> sc-clj
+                  (str/join ", "))
+             "]")
+
+        (number? sc-clj)
+        sc-clj
+
+        (string? sc-clj)
+        (str "\"" sc-clj "\"")
+
+        (map? sc-clj)
+        (->> sc-clj
+             (mapv (fn [[k v]]
+                     (str (name k) ": " v)))
+             (str/join ", "))
+
+        :else
+        (throw (ex-info "Unhandled expression while transpiling into SC"
+                        {:op op
+                         :body body})))
+      (catch Exception e
+        (throw (ex-info "Transpiler error"
+                        {:op op
+                         :body body}
+                        e))))))
+#_(-> [:SynthDef {:name `event
+                  :args [[:freq 240] [:amp 0.5] [:pan 0.0]]}
+       [:vars :env]
+       [:= :env [:EnvGen.ar
+                 [:Env [0 1 1 0] [0.01 0.1 0.2]]
+                 {:doneAction 2}]]
+       [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp]
+                   :pan]]]
+      transpile)
+
+(defonce ^:private *procs
+  (atom []))
+
+(defn stop-procs!
+  "Stop all running sclang process."
+  []
+  (mapv proc/destroy @*procs)
+  (reset! *procs []))
+#_(stop-procs!)
+
+(defn -wrap-code-with-interpreter
+  ([code-str]
+   (-wrap-code-with-interpreter code-str {}))
+  ([code-str {:keys [boot]
+              :or {boot false}}]
+   (let [boot-init-coll ["s.boot;"
+                         "s.waitForBoot({"]
+         boot-end-coll ["});"]
+
+         app-clock-init-coll ["AppClock.sched(0.0,{ arg time;"]
+         app-clock-end-coll ["});"]]
+     #_(println code-str)
+     (format (->> (concat
+                   (when boot boot-init-coll)
+                   app-clock-init-coll
+                   [""
+                    "try {this.interpret("
+                    "%s"
+                    ") }"
+                    "  { |error|"
+                    "    \""
+                    ""
+                    "ERROR"
+                    "----------------------------------"
+                    "\".postln;"
+                    "    error.reportError;"
+                    "    \"-------------------------------------"
+                    ""
+                    "\".postln;"
+                    "  };"
+                    ""]
+                   app-clock-end-coll
+                   (when boot boot-end-coll))
+                  (str/join "\n"))
+             (pr-str code-str)))))
+
+(defn exec!
+  "Execute a sclang script in the background.
+
+  It returns a `babashka.process/process`, `out` and `err` are redirected
+  to stdout.
+
+  Call `stop-procs!` or `babaskha.process/destroy-tree` to kill the
+  returned process.
+
+  E.g.
+
+    (exec! [:. :SynthDef :help])"
+  [sc-clj]
+  (stop-procs!)
+  (let [temp-scd (io/file (str ".overtone/sc/" "_" (random-uuid) ".scd"))
+        _port (or (:port @ov.conn/connection-info*)
+                  (:port (:opts @ov.conn/connection-info*)))
+        str (-wrap-code-with-interpreter (transpile sc-clj))]
+    (io/make-parents temp-scd)
+    (spit temp-scd str)
+    (let [proc (proc/process {:out *out* :err *err*} (sclang-path) temp-scd)]
+      (swap! *procs conj proc)
+      proc)))
+#_(exec! [:. :SynthDef :help])
+;; If you don't have `FoaRotate` installed, you should see an error in the REPL output.
+#_(exec! [:. :FoaRotate :help])
+
+(defn help
+  "Open SC help window for a object."
+  [obj-k]
+  (exec! [:. obj-k :help]))
+#_(help :SynthDef)
+
+(defn- check-proc!
+  [proc args]
+  (loop [counter 5]
+    (cond
+      (zero? counter)
+      (throw (ex-info (str "Process had an error, check the stdout, also check "
+                           "that you have SuperCollider installed, https://supercollider.github.io/downloads")
+                      (merge args {:proc (proc/destroy-tree proc)})))
+
+      (proc/alive? proc)
+      (do (Thread/sleep 200)
+          (recur (dec counter)))
+
+      :else
+      @proc)))
+
+(defn -synthdef-save!
+  "This is an internal function, read the comments in the code to understand
+  what it's doing."
+  [{:keys [synthdef-name file-path resource-path
+           metadata-file-path metadata-resource-path
+           synthdef-str sc-clj]
+    :as args}]
+  (if (and (io/resource resource-path)
+           (io/resource metadata-resource-path)
+           (= (hash sc-clj) (-> (io/resource metadata-resource-path)
+                                slurp
+                                edn/read-string
+                                :code-hash)))
+    ;; Use the resource directly if the code is the same.
+    (io/resource resource-path)
+    ;; Code is not cached, let's run sclang.
+    (let [temp-scd (io/file (str ".overtone/sc/" synthdef-name ".scd"))]
+
+      ;; Make parent folders in the saved path (if necessary).
+      (io/make-parents temp-scd)
+      (io/make-parents file-path)
+
+      ;; Write temp SCD file.
+      (spit temp-scd (-> synthdef-str
+                         (str "\n\n0.exit;")
+                         -wrap-code-with-interpreter))
+
+      ;; Stop existing running processes (if any).
+      (stop-procs!)
+      ;; Run process.
+      (check-proc! (proc/process {:out *out* :err :out} (sclang-path) temp-scd) args)
+
+      (when-not (io/resource resource-path)
+        (throw (ex-info (str "Error when defining a synthdef, resource not found.\nCheck the stdout, also check "
+                             "that your `resources` folder is a `resource` to this Java application.\nAt last, "
+                             "check that SuperCollider is installed, https://supercollider.github.io/downloads")
+                        args)))
+
+      ;; Also, save a metadata file for the generated .scsyndef one so we
+      ;; can use it for caching. Also, people who don't have sclang available
+      ;; on their computers will be able to load the synthdef anyway as it's
+      ;; a normal file (assuming the ugens for external plugins are loaded ofc).
+      (spit metadata-file-path {:code-hash (hash sc-clj)})
+
+      (io/resource resource-path))))
+
+(comment
+
+  (def my-synth
+    (-> [:SynthDef {:name `event-2
+                    :args [[:freq 240] [:amp 0.5] [:pan 0.0]]}
+         [:vars :env]
+         [:= :env [:EnvGen.ar
+                   [:Env [0 1 1 0] [0.01 0.1 0.2]]
+                   {:doneAction 2}]]
+         [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp]
+                     :pan]]]
+        transpile
+        -synthdef-save!
+        ov.synth/synth-load))
+
+  (my-synth :freq 100)
+
+  ())
+
+(defn synth
+  "Defines a synth (SynthDef in SC) from a clojure data representation."
+  [sc-clj]
+  (-> sc-clj
+      transpile
+      -synthdef-save!
+      ov.synth/synth-load))
+
+(defn SynthDef
+  [opts & body]
+  (into [:SynthDef opts]
+        body))
+
+(comment
+
+  (def my-synth
+    (synth
+     (SynthDef
+      {:name 'event
+       :args [[:freq 120] [:amp 0.5] [:pan 0.0]]}
+      [:vars :env]
+      [:= :env [:EnvGen.ar
+                [:Env [0 1 1 0] [0.01 0.1 0.2]]
+                {:doneAction 2}]]
+      [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp]
+                  :pan]])))
+
+  (my-synth)
+
+  ())
+
+(defmacro defsynth
+  "Defines a synth (SynthDef in SC) from a clojure data representation.
+
+  This puts a metadata file and a .scsyndef file in a location derived from `s-name`
+  inside `resources-dir`.
+
+  `opts-map` can have the following optional keys
+    - `:args`, this is already derived from `params`, so you don't need to set it
+    - `:resources-dir`, default to \"resources\", it should be a resource folder
+
+  This will call your SuperColliders's `sclang` command at the first time while using `sc-clj`
+  for caching. As long you distribute the generated .scsyndef file in the right location and you don't
+  modify `sc-clj`, the final user won't need to have `sclang` or SuperCollider installed
+  on their machines."
+  [s-name & s-form]
+  {:arglists '([name doc-string? opts-map? params sc-clj])}
+  (let [[doc-string opts-map params sc-clj] (cond
+                                              (string? (first s-form))
+                                              (if (map? (second s-form))
+                                                [(first s-form) (second s-form) (nth s-form 2) (drop 3 s-form)]
+                                                [(first s-form) nil (nth s-form 1) (drop 2 s-form)])
+
+                                              (map? (first s-form))
+                                              [nil (first s-form) (nth s-form 1) (drop 2 s-form)]
+
+                                              :else
+                                              [nil nil (first s-form) (drop 1 s-form)])]
+    `(do (def ~s-name
+           (synth
+            (SynthDef
+             (merge {:name (symbol (str *ns*) ~(str s-name))
+                     :args ~(->> params
+                                 (partition-all 2 2)
+                                 (mapv (fn [[arg default]]
+                                         [(keyword arg) default])))}
+                    ~opts-map)
+             ~@sc-clj)))
+         (alter-meta! (var ~s-name) merge (cond-> (meta ~s-name)
+                                            ~doc-string (assoc :doc ~doc-string)))
+         (var ~s-name))))
+
+(comment
+
+  (defsynth my-synth-3
+    "Some synth."
+    [freq 440, amp 0.5, pan 0.0]
+    [:vars :env]
+    [:= :env [:EnvGen.ar [:Env [0 1 1 0] [0.01 0.1 0.2]] {:doneAction 2}]]
+    [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp]
+                :pan]])
+
+  (my-synth-3)
+
+  ())

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -101,6 +101,10 @@
                           (name var-identifier)))
                   (str/join ", ")))
 
+        (= :raw op)
+        (->> body
+             (str/join "; "))
+
         (and (keyword? op) body)
         (str (name op)
              "( "

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -352,7 +352,22 @@
   This will call your SuperColliders's `sclang` command at the first time while using `sc-clj`
   for caching. As long you distribute the generated .scsyndef file in the right location and you don't
   modify `sc-clj`, the final user won't need to have `sclang` or SuperCollider installed
-  on their machines."
+  on their machines.
+
+  --------------------
+  ;; Example.
+  ;; When you evaluate the form below, you should see new files in
+  ;; `resources/sc/synthdef`.
+  (sclang/defsynth my-synth
+    \"Some synth.\"
+    [freq 440, amp 0.5, pan 0.0]
+    [:vars :env]
+    [:= :env [:EnvGen.ar [:Env [0 1 1 0] [0.01 0.1 0.2]] {:doneAction 2}]]
+    [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp]
+                :pan]])
+
+  ;; Run it
+  (my-synth :freq 220)"
   [s-name & s-form]
   {:arglists '([name doc-string? opts-map? params sc-clj])}
   (let [[doc-string opts-map params sc-clj] (cond

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -232,7 +232,7 @@
 
 (defn- check-proc!
   [proc args]
-  (loop [counter 5]
+  (loop [counter 15]
     (cond
       (zero? counter)
       (throw (ex-info (str "Process had an error, check the stdout, also check "
@@ -255,10 +255,10 @@
     :as args}]
   (if (and (io/resource resource-path)
            (io/resource metadata-resource-path)
-           (= (hash sc-clj) (-> (io/resource metadata-resource-path)
-                                slurp
-                                edn/read-string
-                                :code-hash)))
+           (= sc-clj (-> (io/resource metadata-resource-path)
+                         slurp
+                         edn/read-string
+                         :sc-clj)))
     ;; Use the resource directly if the code is the same.
     (io/resource resource-path)
     ;; Code is not cached, let's run sclang.
@@ -288,7 +288,9 @@
       ;; can use it for caching. Also, people who don't have sclang available
       ;; on their computers will be able to load the synthdef anyway as it's
       ;; a normal file (assuming the ugens for external plugins are loaded ofc).
-      (spit metadata-file-path {:code-hash (hash sc-clj)})
+      (spit metadata-file-path (binding [*print-length* nil
+                                         *print-level* nil]
+                                 (pr-str {:sc-clj sc-clj})))
 
       (io/resource resource-path))))
 

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -389,6 +389,8 @@
 
   ;; Run it
   (my-synth :freq 220)"
+  {:clj-kondo/ignore [:unresolved-symbol]
+   :clj-kondo/lint-as 'clojure.core/def}
   [s-name & s-form]
   {:arglists '([name doc-string? opts-map? params sc-clj])}
   (let [[doc-string opts-map params sc-clj] (cond

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -61,8 +61,17 @@
                                 "(" (str "\"" synthdef-name "\"" ",") " {\n"
                                 (->> [(str "arg "
                                            (->> args
-                                                (mapv (fn [[arg-identifier default]]
-                                                        (str (name arg-identifier) "=" default)))
+                                                (mapv (fn [k-or-seq]
+                                                        (let [[arg-identifier default] (if (sequential? k-or-seq)
+                                                                                         k-or-seq
+                                                                                         [k-or-seq])]
+                                                          (if default
+                                                            (str (name arg-identifier)
+                                                                 "="
+                                                                 "("
+                                                                 (transpile default)
+                                                                 ")")
+                                                            (name arg-identifier)))))
                                                 (str/join ", "))
                                            ";")
 

--- a/src/overtone/sc/sclang.clj
+++ b/src/overtone/sc/sclang.clj
@@ -244,9 +244,11 @@
   (exec! [:. obj-k :help]))
 #_(help :SynthDef)
 
+(def ^:dynamic *-check-proc-max-count* 15)
+
 (defn- check-proc!
   [proc args]
-  (loop [counter 100]
+  (loop [counter *-check-proc-max-count*]
     (cond
       (zero? counter)
       (throw (ex-info (str "Process had an error, check the stdout, also check "

--- a/src/overtone/sc/synth.clj
+++ b/src/overtone/sc/synth.clj
@@ -713,7 +713,7 @@
 (defn synth?
   "Returns true if s is a synth, false otherwise."
   [s]
-  (= overtone.sc.synth.Synth (type s)))
+  (instance? Synth s))
 
 (def ^{:dynamic true} *demo-time* 2000)
 

--- a/test/overtone/sc/sclang_test.clj
+++ b/test/overtone/sc/sclang_test.clj
@@ -12,7 +12,7 @@
     (is (= '{:sc-clj
              [:SynthDef
               {:name overtone.sc.sclang-test/event,
-               :args [[:freq 120] [:amp 0.5] [:pan 0.0]]}
+               :args [[:freq] [:amp 0.5] :pan]}
               [:vars :env]
               [:=
                :env
@@ -29,7 +29,7 @@
              "sc/synthdef/overtone_sc_sclang-test_event.edn",
              :synthdef-str
              "SynthDef(\"overtone_sc_sclang-test_event\", {
-  arg freq=120, amp=0.5, pan=0.0;
+  arg freq, amp=(0.5), pan;
   var env;
   env = EnvGen.ar( Env( [0, 1, 1, 0], [0.01, 0.1, 0.2] ), doneAction: 2 );
   0.postln; \"eita\".postln;
@@ -37,7 +37,7 @@
 }).writeDefFile(\"resources/sc/synthdef\").add;",
              :synthdef-str-vec
              ["SynthDef(\"overtone_sc_sclang-test_event\", {"
-              "  arg freq=120, amp=0.5, pan=0.0;"
+              "  arg freq, amp=(0.5), pan;"
               "  var env;"
               "  env = EnvGen.ar( Env( [0, 1, 1, 0], [0.01, 0.1, 0.2] ), doneAction: 2 );"
               "  0.postln; \"eita\".postln;"
@@ -46,7 +46,7 @@
            (sclang/transpile
             (sclang/SynthDef
              {:name `event
-              :args [[:freq 120] [:amp 0.5] [:pan 0.0]]}
+              :args [[:freq] [:amp 0.5] :pan]}
              [:vars :env]
              [:= :env [:EnvGen.ar
                        [:Env [0 1 1 0] [0.01 0.1 0.2]]

--- a/test/overtone/sc/sclang_test.clj
+++ b/test/overtone/sc/sclang_test.clj
@@ -17,6 +17,7 @@
               [:=
                :env
                [:EnvGen.ar [:Env [0 1 1 0] [0.01 0.1 0.2]] {:doneAction 2}]]
+              [:raw "0.postln" "\"eita\".postln"]
               [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp] :pan]]],
              :synthdef-name "overtone_sc_sclang-test_event",
              :file-path
@@ -31,6 +32,7 @@
   arg freq=120, amp=0.5, pan=0.0;
   var env;
   env = EnvGen.ar( Env( [0, 1, 1, 0], [0.01, 0.1, 0.2] ), doneAction: 2 );
+  0.postln; \"eita\".postln;
   Out.ar( 0, Pan2.ar( Blip.ar( freq ) * env * amp, pan ) );
 }).writeDefFile(\"resources/sc/synthdef\").add;",
              :synthdef-str-vec
@@ -38,6 +40,7 @@
               "  arg freq=120, amp=0.5, pan=0.0;"
               "  var env;"
               "  env = EnvGen.ar( Env( [0, 1, 1, 0], [0.01, 0.1, 0.2] ), doneAction: 2 );"
+              "  0.postln; \"eita\".postln;"
               "  Out.ar( 0, Pan2.ar( Blip.ar( freq ) * env * amp, pan ) );"
               "}).writeDefFile(\"resources/sc/synthdef\").add;"]}
            (sclang/transpile
@@ -48,5 +51,6 @@
              [:= :env [:EnvGen.ar
                        [:Env [0 1 1 0] [0.01 0.1 0.2]]
                        {:doneAction 2}]]
+             [:raw "0.postln" "\"eita\".postln"]
              [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp]
                          :pan]]))))))

--- a/test/overtone/sc/sclang_test.clj
+++ b/test/overtone/sc/sclang_test.clj
@@ -72,7 +72,8 @@
                                       (sclang/munge-synthdef-name (name g))))
             scsyndef-file (io/file (format "resources/sc/synthdef/overtone_sc_sclang-test_%s.scsyndef"
                                            (sclang/munge-synthdef-name (name g))))]
-        (try (let [f (binding [*ns* (the-ns this-ns)]
+        (try (let [f (binding [*ns* (the-ns this-ns)
+                               sclang/*-check-proc-max-count* 100]
                        (eval `(sclang/defsynth ~g
                                 "Some synth."
                                 [~'freq 440, ~'amp 0.5, ~'pan 0.0]

--- a/test/overtone/sc/sclang_test.clj
+++ b/test/overtone/sc/sclang_test.clj
@@ -1,0 +1,52 @@
+(ns overtone.sc.sclang-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [overtone.sc.sclang :as sclang]))
+
+(deftest transpile-test
+  (testing "Simple"
+    (is (= "SynthDef.help"
+           (sclang/transpile [:. :SynthDef :help]))))
+
+  (testing "SynthDef"
+    (is (= '{:sc-clj
+             [:SynthDef
+              {:name overtone.sc.sclang-test/event,
+               :args [[:freq 120] [:amp 0.5] [:pan 0.0]]}
+              [:vars :env]
+              [:=
+               :env
+               [:EnvGen.ar [:Env [0 1 1 0] [0.01 0.1 0.2]] {:doneAction 2}]]
+              [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp] :pan]]],
+             :synthdef-name "overtone_sc_sclang-test_event",
+             :file-path
+             "resources/sc/synthdef/overtone_sc_sclang-test_event.scsyndef",
+             :resource-path "sc/synthdef/overtone_sc_sclang-test_event.scsyndef",
+             :metadata-file-path
+             "resources/sc/synthdef/overtone_sc_sclang-test_event.edn",
+             :metadata-resource-path
+             "sc/synthdef/overtone_sc_sclang-test_event.edn",
+             :synthdef-str
+             "SynthDef(\"overtone_sc_sclang-test_event\", {
+  arg freq=120, amp=0.5, pan=0.0;
+  var env;
+  env = EnvGen.ar( Env( [0, 1, 1, 0], [0.01, 0.1, 0.2] ), doneAction: 2 );
+  Out.ar( 0, Pan2.ar( Blip.ar( freq ) * env * amp, pan ) );
+}).writeDefFile(\"resources/sc/synthdef\").add;",
+             :synthdef-str-vec
+             ["SynthDef(\"overtone_sc_sclang-test_event\", {"
+              "  arg freq=120, amp=0.5, pan=0.0;"
+              "  var env;"
+              "  env = EnvGen.ar( Env( [0, 1, 1, 0], [0.01, 0.1, 0.2] ), doneAction: 2 );"
+              "  Out.ar( 0, Pan2.ar( Blip.ar( freq ) * env * amp, pan ) );"
+              "}).writeDefFile(\"resources/sc/synthdef\").add;"]}
+           (sclang/transpile
+            (sclang/SynthDef
+             {:name `event
+              :args [[:freq 120] [:amp 0.5] [:pan 0.0]]}
+             [:vars :env]
+             [:= :env [:EnvGen.ar
+                       [:Env [0 1 1 0] [0.01 0.1 0.2]]
+                       {:doneAction 2}]]
+             [:Out.ar 0 [:Pan2.ar [:* [:Blip.ar :freq] :env :amp]
+                         :pan]]))))))


### PR DESCRIPTION
Sometimes we want to use a new plugin, package, function or SC Class that's only available in the SuperCollider environment and that would require lots of work to be ported into `overtone`.

This PR gives better support to call `sclang` command (if available) from the REPL while also adding some helpers to convert code to SC's default client lang.

The primary focus for this new effort is in being able to generate a SynthDef easily and reproducible (via caching in generated file) without having to open SC's IDE.

See https://clojurians.slack.com/archives/C053Q1QSG/p1730176977002979 for initial example and discussion.

- With `overtone.sc.sclang/defsynth`, we add the ability to transpile, run `sclang`, save a SynthDef into disk (with metadata), load this SynthDef into `overtone` in one step.
- The final users can keep using this new `defsynth` without having `sclang` available on their machines as we won't need to call `sclang` if the code hasn't changed and the saved SynthDef file is already in place