### PR TITLE
Fix `buzz` crashing SC and use parameter `cutoff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Fixed
 - [573](https://github.com/overtone/overtone/pull/573): reduce likelihood of choosing a used random port for `scsynth`
+- [578](https://github.com/overtone/overtone/pull/578): Fixed `overtone.sc.synth/buzz` instrument.
 
 ## Changed
 

--- a/src/overtone/inst/synth.clj
+++ b/src/overtone/inst/synth.clj
@@ -182,11 +182,11 @@
     audio))
 
 (definst buzz
-  [pitch 40 cutoff 300 dur 200]
-  (let [lpf-lev (* (+ 1 (lf-noise1:kr 10)) 400)
+  [pitch 40 cutoff 400 dur 200]
+  (let [lpf-lev (* (+ 1 (lf-noise1:kr 10)) cutoff)
         a       (lpf (saw (midicps pitch)) lpf-lev)
         b       (sin-osc (midicps (- pitch 12)))
-        env     (env-gen 1 1 0 1 2 (perc 0.01 (/ dur 1000)))]
+        env     (env-gen (perc 0.01 (/ dur 1000)) :action FREE)]
     (* env (+ a b))))
 
 (definst bass


### PR DESCRIPTION
As it was, `buzz` would segfault SC, presumably because of integer `envelope` parameter.