### PR TITLE
Allow negative arguments to nth-interval

### DIFF
--- a/src/overtone/music/pitch.clj
+++ b/src/overtone/music/pitch.clj
@@ -362,7 +362,10 @@
        start of the scale."
   ([n] (nth-interval :diatonic n))
   ([scale n]
-   (reduce + (take n (cycle (scale SCALE))))))
+   (let [s (scale SCALE)]
+     (if (< n 0)
+       (- (nth-interval scale (+ n (count s))) 12)
+       (reduce + (take n (cycle s)))))))
 
 (def DEGREE {:i     1
              :ii    2


### PR DESCRIPTION
For negative intervals, we can instead ask what the interval for the next octave up is, and subtract 12 from the result. An octave always is an increment of 12, and the number of intervals per octave depends on the length of the SCALE.