### PR TITLE
Enable insts to be loaded before server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [573](https://github.com/overtone/overtone/pull/573): reduce likelihood of choosing a used random port for `scsynth`
 - [578](https://github.com/overtone/overtone/pull/578): Fixed `overtone.sc.synth/buzz` instrument.
 - [577](https://github.com/overtone/overtone/pull/577): Fix `/cmd` validation
+- [582](https://github.com/overtone/overtone/pull/582): Enable insts to be loaded before server startup
 - [583](https://github.com/overtone/overtone/pull/583): `bass` and `grunge-bass` in `overtone.inst.synth` both now mix 3 audio channels (center freq and detuned high and low) to a single channel.
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [583](https://github.com/overtone/overtone/pull/583): `bass` and `grunge-bass` in `overtone.inst.synth` both now mix 3 audio channels (center freq and detuned high and low) to a single channel.
 
 ## Breaking Changes
-- [582](https://github.com/overtone/overtone/pull/582) adds the potemkin lib, now insts accept up to 21 arguments
+- [582](https://github.com/overtone/overtone/pull/582) adds the potemkin lib, which makes Inst accept up to 21 arguments if you use `apply`, also the Inst class has two more params (`m` and `mta`) for its constructor
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - [582](https://github.com/overtone/overtone/pull/582): Enable insts to be loaded before server startup
 - [583](https://github.com/overtone/overtone/pull/583): `bass` and `grunge-bass` in `overtone.inst.synth` both now mix 3 audio channels (center freq and detuned high and low) to a single channel.
 
+## Breaking Changes
+- [582](https://github.com/overtone/overtone/pull/582) adds the potemkin lib, now insts accept up to 21 arguments
+
 ## Changed
 
 # 0.16.3331 (2024-11-07 / 09b1fca)

--- a/deps.edn
+++ b/deps.edn
@@ -14,8 +14,13 @@
 
  :aliases
  {:test
-  {:extra-paths ["test"]}
+  {:extra-paths ["test"]
+   :extra-deps {nubank/matcher-combinators {:mvn/version "3.9.1"}}}
+
   :test-runner
-  {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
+  {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
+                nubank/matcher-combinators {:mvn/version "3.9.1"}}
    :main-opts ["-m" "kaocha.runner"]}
-  :1.12 {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0"}}}}}
+
+  :1.12
+  {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,10 @@
 
   ;; For processes, it supports Windows well and it has some niceties that
   ;; clojure.java.shell doesn't have.
-  babashka/process {:mvn/version "0.5.22"}}
+  babashka/process {:mvn/version "0.5.22"}
+
+  ;; For custom data structures.
+  potemkin/potemkin {:mvn/version "0.4.7"}}
 
  :aliases
  {:test

--- a/src/overtone/sc/machinery/synthdef.clj
+++ b/src/overtone/sc/machinery/synthdef.clj
@@ -378,12 +378,13 @@
 ;;   The eventual goal is to be able to take any SuperCollider scsyndef
 ;;   file, and produce equivalent clojure code that can be re-edited.
 
-(defn- param-vector [params pnames]
+(defn- param-vector
   "Create a synthdef parameter vector."
+  [params pnames]
   (vec (flatten
-         (map #(list (symbol (:name %1))
-                     (nth params (:index %1)))
-              pnames))))
+        (map #(list (symbol (:name %1))
+                    (nth params (:index %1)))
+             pnames))))
 
 (defn- ugen-form
   "Create a ugen form."
@@ -436,7 +437,7 @@
   While this probably won't create a synth definition that can
   directly compile, it can still be helpful when trying to reverse
   engineer a synth."
-  [{:keys [name constants params pnames ugens] :as sdef}]
+  [{:keys [name constants params pnames ugens] :as _sdef}]
   (let [sname (symbol name)
         param-vec (param-vector params pnames)
         ugens (map #(assoc % :sname %2)

--- a/src/overtone/studio/inst.clj
+++ b/src/overtone/studio/inst.clj
@@ -18,7 +18,8 @@
   (:require [clojure.pprint]
             [overtone.sc.protocols :as protocols]
             [overtone.sc.util]
-            [overtone.sc.machinery.server.comms :refer [with-server-sync]]))
+            [overtone.sc.machinery.server.comms :refer [with-server-sync]]
+            [overtone.libs.deps :as ov.deps]))
 
 (defonce ^{:private true} __RECORDS__
   (do
@@ -28,10 +29,10 @@
                          volume pan
                          n-chans]
       (fn [this & args]
-        (apply synth-player sdef params this [:tail instance-group] args))
+        (apply synth-player sdef params this [:tail @instance-group] args))
 
       to-sc-id*
-      (to-sc-id [_] (to-sc-id instance-group)))))
+      (to-sc-id [_] (to-sc-id @instance-group)))))
 
 (derive Inst :overtone.sc.node/node)
 
@@ -81,14 +82,14 @@
   "Control the volume of a single instrument."
   [inst vol]
   (ensure-node-active! inst)
-  (ctl (:mixer inst) :volume vol)
+  (ctl @(:mixer inst) :volume vol)
   (reset! (:volume inst) vol))
 
 (defn inst-pan!
   "Control the pan setting of a single instrument."
   [inst pan]
   (ensure-node-active! inst)
-  (ctl (:mixer inst) :pan pan)
+  (ctl @(:mixer inst) :pan pan)
   (reset! (:pan inst) pan))
 
 (defmulti inst-fx!
@@ -99,7 +100,7 @@
 (defmethod inst-fx! :mono
   [inst fx & args]
   (ensure-node-active! inst)
-  (let [fx-group (:fx-group inst)
+  (let [fx-group @(:fx-group inst)
         bus      (:bus inst)
         fx-id    (apply fx [:tail fx-group] :bus bus args)]
     fx-id))
@@ -107,7 +108,7 @@
 (defmethod inst-fx! :stereo
   [inst fx & args]
   (ensure-node-active! inst)
-  (let [fx-group (:fx-group inst)
+  (let [fx-group @(:fx-group inst)
         bus-l    (to-sc-id (:bus inst))
         bus-r    (inc bus-l)
         fx-ids   [(apply fx [:tail fx-group] :bus bus-l args)
@@ -117,7 +118,7 @@
 (defn clear-fx
   [inst]
   (ensure-node-active! inst)
-  (group-clear (:fx-group inst))
+  (group-clear @(:fx-group inst))
   :clear)
 
 (defmacro pre-inst
@@ -155,33 +156,42 @@
   [o]
   (= overtone.studio.inst.Inst (type o)))
 
+(defmacro with-server-sync-atom
+  [action-fn error-msg]
+  `(atom
+    (when (server-connected?)
+      (with-server-sync ~action-fn ~error-msg))))
+
 (defmacro inst
   [sname & args]
-  (ensure-connected!)
   `(let [[sname# full-name# params# ugens# constants# n-chans# inst-bus#] (pre-inst ~sname ~@args)
          new-inst# (get (:instruments @studio*) full-name#)
+
          container-group# (or (:group new-inst#)
-                              (with-server-sync
+                              (with-server-sync-atom
                                 #(group (str "Inst " sname# " Container")
                                         :tail (:instrument-group @studio*))
                                 "whilst creating an inst container group"))
 
-         instance-group#  (or (:instance-group new-inst#)
-                              (with-server-sync
-                                #(group (str "Inst " sname#)
-                                        :head container-group#)
-                                "whilst creating an inst instance group"))
+         instance-group# (or (:instance-group new-inst#)
+                             (with-server-sync-atom
+                               #(group (str "Inst " sname#)
+                                       :head @container-group#)
+                               "whilst creating an inst instance group"))
 
          fx-group#        (or (:fx-group new-inst#)
-                              (with-server-sync
+                              (with-server-sync-atom
                                 #(group (str "Inst " sname# " FX")
-                                        :tail container-group#)
+                                        :tail @container-group#)
                                 "whilst creating an inst fx group"))
 
          imixer#    (or (:mixer new-inst#)
-                        (inst-mixer n-chans#
-                                    [:tail container-group#]
-                                    :in-bus inst-bus#))
+                        (with-server-sync-atom
+                          #(inst-mixer n-chans#
+                                       [:tail @container-group#]
+                                       :in-bus inst-bus#)
+                          "whilst creating an inst imixer"))
+
          sdef#      (synthdef sname# params# ugens# constants#)
          arg-names# (map :name params#)
          params-with-vals# (map #(assoc % :value (control-proxy-value-atom full-name# %)) params#)
@@ -199,6 +209,28 @@
      (add-instrument inst#)
      (event :new-inst :inst inst#)
      inst#))
+
+(defn- load-all-insts
+  []
+  (doseq [[sname {:keys [instance-group fx-group mixer n-chans bus]
+                  container-group :group}]
+          (:instruments @studio*)]
+    (reset! container-group (group (str "Inst " sname " Container")
+                                   :tail (:instrument-group @studio*)))
+
+    (reset! instance-group (group (str "Inst " sname)
+                                  :head @container-group))
+
+    (reset! fx-group (group (str "Inst " sname " FX")
+                            :tail @container-group))
+
+    (reset! mixer (inst-mixer n-chans
+                              [:tail @container-group]
+                              :in-bus bus)))
+
+  (ov.deps/satisfy-deps :insts-loaded))
+
+(ov.deps/on-deps :studio-setup-completed ::load-all-insts load-all-insts)
 
 (defmacro definst
   "Define an instrument and return a player function. The instrument
@@ -303,18 +335,18 @@
 (defn- inst-block-until-ready*
   [inst]
   (when (block-node-until-ready?)
-    (doseq [sub-node [(:fx-group inst)
-                      (:group inst)
-                      (:instance-group inst)
-                      (:mixer inst)]]
+    (doseq [sub-node [@(:fx-group inst)
+                      @(:group inst)
+                      @(:instance-group inst)
+                      @(:mixer inst)]]
       (node-block-until-ready sub-node))))
 
 (defn- inst-status*
   [inst]
-  (let [sub-nodes [(:fx-group inst)
-                   (:group inst)
-                   (:instance-group inst)
-                   (:mixer inst)]]
+  (let [sub-nodes [@(:fx-group inst)
+                   @(:group inst)
+                   @(:instance-group inst)
+                   @(:mixer inst)]]
     (cond
      (some #(= :loading @(:status %)) sub-nodes) :loading
      (some #(= :destroyed @(:status %)) sub-nodes) :destroyed
@@ -337,7 +369,7 @@
    :node-map-n-controls    node-map-n-controls*}
 
   protocols/IKillable
-  {:kill* (fn [this] (group-deep-clear (:instance-group this)))}
+  {:kill* (fn [this] (group-deep-clear @(:instance-group this)))}
 
   ISynthNodeStatus
   {:node-status            inst-status*

--- a/src/overtone/studio/mixer.clj
+++ b/src/overtone/studio/mixer.clj
@@ -235,7 +235,7 @@
   "Frees all synth notes for each of the current instruments"
   [_event-info]
   (doseq [[_name inst] (:instruments @studio*)]
-    (group-clear @(:instance-group inst))))
+    (group-clear (:instance-group inst))))
 
 (on-sync-event :reset reset-instruments ::reset-instruments)
 
@@ -258,4 +258,4 @@
   (let [[{:keys [instruments]} _]
         (swap-vals! studio* assoc :instruments {})]
     (doseq [[_name inst] instruments]
-      (group-free @(:group inst)))))
+      (group-free (:group inst)))))

--- a/src/overtone/studio/mixer.clj
+++ b/src/overtone/studio/mixer.clj
@@ -215,9 +215,10 @@
                             "whilst creating the Studio group")
         insts-with-groups (map-vals (fn [val]
                                       (assoc val :group
-                                             (with-server-sync
-                                               #(group (str "Recreated Inst Group") :tail g)
-                                               "whist creating the Recreated Inst Group")))
+                                             (atom
+                                              (with-server-sync
+                                                #(group (str "Recreated Inst Group") :tail g)
+                                                "whist creating the Recreated Inst Group"))))
                                     (:instruments @studio*))]
     (swap! studio* assoc
            :instrument-group g
@@ -234,7 +235,7 @@
   "Frees all synth notes for each of the current instruments"
   [_event-info]
   (doseq [[_name inst] (:instruments @studio*)]
-    (group-clear (:instance-group inst))))
+    (group-clear @(:instance-group inst))))
 
 (on-sync-event :reset reset-instruments ::reset-instruments)
 
@@ -257,4 +258,4 @@
   (let [[{:keys [instruments]} _]
         (swap-vals! studio* assoc :instruments {})]
     (doseq [[_name inst] instruments]
-      (group-free (:group inst)))))
+      (group-free @(:group inst)))))

--- a/test/overtone/studio_test.clj
+++ b/test/overtone/studio_test.clj
@@ -38,8 +38,7 @@
               :instance-group nil
               :fx-group nil
               :mixer nil}
-             (-> (select-keys kick [:group :instance-group :fx-group :mixer])
-                 (update-vals deref))))))
+             (select-keys kick [:group :instance-group :fx-group :mixer])))))
 
   (testing "after starting server"
     (with-sync-reset
@@ -55,5 +54,4 @@
                 {:instance-group some?
                  :fx-group some?
                  :mixer some?}
-                (-> (select-keys kick [:instance-group :fx-group :mixer])
-                    (update-vals deref))))))))))
+                (select-keys kick [:instance-group :fx-group :mixer])))))))))

--- a/test/overtone/studio_test.clj
+++ b/test/overtone/studio_test.clj
@@ -1,55 +1,59 @@
 (ns overtone.studio-test
-  (:use overtone.live))
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [overtone.test-helper :refer [ensure-server with-sync-reset]]
+   [overtone.libs.deps :as ov.deps]
+   ;; We call it just to make sure that we are able to load the built-in insts
+   ;; before starting the server.
+   overtone.inst.synth
+   matcher-combinators.test)
+  (:use overtone.core))
 
-(comment
-  (defn inst-test []
-    (definst bar [freq 200]
-      (* (env-gen (perc 0.1 0.8) 1 1 0 1 FREE)
-         (rlpf (saw freq) (* 1.1 freq) 0.3)
-         0.4))
+(definst bar [freq 200]
+  (* (env-gen (perc 0.1 0.8) 1 1 0 1 FREE)
+     (rlpf (saw freq) (* 1.1 freq) 0.3)
+     0.4))
 
-    (definst buz [freq 200]
-      (* (env-gen (perc 0.1 0.8) 1 1 0 1 FREE)
-         (+ (sin-osc (/ freq 2))
-            (rlpf (saw freq) (* 1.1 freq) 0.3))
-         0.4)))
+(definst buz [freq 200]
+  (* (env-gen (perc 0.1 0.8) 1 1 0 1 FREE)
+     (+ (sin-osc (/ freq 2))
+        (rlpf (saw freq) (* 1.1 freq) 0.3))
+     0.4))
 
+(definst foo [freq 440]
+  (* 0.8
+     (env-gen (perc 0.1 0.4) :action FREE)
+     (rlpf (saw [freq (* 0.98 freq)])
+           (mul-add (sin-osc:kr 30) 100 (* 1.8 freq)) 0.2)))
 
-  (def metro (metronome 128))
+(definst kick [freq 240]
+  (* 0.8
+     (env-gen (perc 0.01 0.3) :action FREE)
+     (sin-osc freq)))
 
-  (defonce sequences (atom {}))
+(deftest studio-test
+  (when-not (server-connected?)
+    (testing "before starting server"
+      (is (= {:group nil
+              :instance-group nil
+              :fx-group nil
+              :mixer nil}
+             (-> (select-keys kick [:group :instance-group :fx-group :mixer])
+                 (update-vals deref))))))
 
-  (defn sequence-pattern [inst pat]
-    (swap! sequences assoc inst pat))
+  (testing "after starting server"
+    (with-sync-reset
+      (fn []
+        (ensure-server
+         (fn []
+           ;; Wait for insts loading after the server startup.
+           (ov.deps/wait-until-deps-satisfied [:insts-loaded])
 
-  (defn sequencer-player [beat]
-    (doseq [[inst pat] @sequences]
-      (pat inst))
-    (apply-at #'sequence-player (@sequencer-metro* (inc beat)) (inc beat)))
-
-  (defn sequencer-play []
-    (sequencer-player (metro)))
-
-  (def _ nil)
-  (def X 440)
-  (def x 220)
-
-  (definst foo [freq 440]
-    (* 0.8
-       (env-gen (perc 0.1 0.4) :action FREE)
-       (rlpf (saw [freq (* 0.98 freq)])
-             (mul-add (sin-osc:kr 30) 100 (* 1.8 freq)) 0.2)))
-
-  (definst kick [freq 240]
-    (* 0.8
-       (env-gen (perc 0.01 0.3) :action FREE)
-       (sin-osc freq)))
-
-  (defn test-session []
-    (track :kick kick)
-    (track-fn :kick (fn [] [220]))
-    (session-play))
-
-  )
-;  (track :foo #'foo)
-;  (track-fn :foo #(if (> (rand) 0.7) (+ 300 (rand-int 500))))
+           ;; Test it!
+           (is (match?
+                ;; We don't test `:group` here as it's `nil` while loading.
+                {:instance-group some?
+                 :fx-group some?
+                 :mixer some?}
+                (-> (select-keys kick [:instance-group :fx-group :mixer])
+                    (update-vals deref))))))))))


### PR DESCRIPTION
This makes `:group`, `:instance-group`, `:fx-group` and `:mixer` atoms in a `Inst` so we can enable the loading of the insts at anytime, even before the server startup.