### PR TITLE
Mix in detune channels of `bass` and `grunge-bass` to a single instrument channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Linux dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y pulseaudio dbus-x11 libssl-dev supercollider-language supercollider-server sc3-plugins-server alsa-base alsa-utils jackd2 libjack-jackd2-dev libjack-jackd2-0 libasound2-dev librtmidi-dev pulseaudio-module-jack
         if: matrix.os == 'ubuntu-latest'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [573](https://github.com/overtone/overtone/pull/573): reduce likelihood of choosing a used random port for `scsynth`
 - [578](https://github.com/overtone/overtone/pull/578): Fixed `overtone.sc.synth/buzz` instrument.
 - [577](https://github.com/overtone/overtone/pull/577): Fix `/cmd` validation
+- [583](https://github.com/overtone/overtone/pull/583): `bass` and `grunge-bass` in `overtone.inst.synth` both now mix 3 audio channels (center freq and detuned high and low) to a single channel.
 
 ## Changed
 

--- a/src/overtone/inst/synth.clj
+++ b/src/overtone/inst/synth.clj
@@ -195,10 +195,13 @@
         src  (saw [freq (* 0.98 freq) (* 2.015 freq)])
         src  (clip2 (* 1.3 src) 0.8)
         sub  (sin-osc (/ freq 2))
-        filt (resonz (rlpf src (* 4.4 freq) 0.09) (* 2.0 freq) 2.9)]
-    (* env amp (fold:ar (distort (* 1.3 (+ filt sub))) 0.08))))
+        filt (resonz (rlpf src (* 4.4 freq) 0.09) (* 2.0 freq) 2.9)
+        fld  (fold:ar (distort (* 1.3 (+ filt sub))) 0.08)]
+    ;; Three distinct audio channels created in `saw` above need to be
+    ;; mixed down to one for output
+    (* env amp (mix fld))))
 
-(definst daf-bass [freq 440 gate 1 amp 1 out-bus 0]
+(definst daf-bass [freq 440 gate 1 amp 1]
   (let [harm [1 1.01 2 2.02 3.5 4.01 5.501]
         harm (concat harm (map #(* 2 %) harm))
         snd  (* 2 (distort (sum (sin-osc (* freq harm)))))
@@ -217,7 +220,7 @@
         meat    (ring4 filt sub)
         sliced  (rlpf meat (* 2 freq) 0.1)
         bounced (free-verb sliced 0.8 0.9 0.2)]
-    (* amp env bounced)))
+    (* amp env (mix bounced))))
 
 (definst vintage-bass
   [note 40 velocity 80 t 0.6 amp 1 gate 1]


### PR DESCRIPTION
`bass` and `grunge-bass` in `overtone.inst.synth` produce three audio channels from their synth algorithms using multi-channel expansion to add some up and down freq detune. The mixer `stereo-inst-mixer` used to mix the output of instruments that generate more than one channel of audio ignores channels other than the first two, it therefore drops the detuned up audio entirely. Also, it uses `balance2` to pan, which means that by default the intended `freq` tone would come from the left channel and the detuned down tone would come from the right channel.

This is broken and not the intention of the `bass` and `grunge-bass` authors. The fix is to mix the three audio paths into one at the end of the instruments' synths.