### PR TITLE
Pattern lib fixes to `:proto` param and `:clock` consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Linux dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y pulseaudio dbus-x11 libssl-dev supercollider-language supercollider-server sc3-plugins-server alsa-base alsa-utils jackd2 libjack-jackd2-dev libjack-jackd2-0 libasound2-dev librtmidi-dev pulseaudio-module-jack
         if: matrix.os == 'ubuntu-latest'
 

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -417,6 +417,7 @@
   ;; TODO: this is not yet taking :offset into account
   (let [align (:align opts (:align player :wait))
         quant (:quant opts (:quant player 4))
+        proto (:proto opts (:proto player))
         playing (some :playing (vals @pplayers))
         beat (if playing
                (max (or beat 1) (clock))
@@ -452,7 +453,8 @@
            :playing true
            :beat beat
            :pseq pseq
-           :quant quant)))
+           :quant quant
+           :proto proto)))
 
 (defn presume
   ([k]

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -19,7 +19,7 @@
   ^:private
   player-pool (at-at/mk-pool))
 
-(defonce ^:private pplayers (atom {}))
+(defonce pplayers (atom {}))
 
 (def ^:private event-defaults
   {:note

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -358,7 +358,7 @@
     :quant  4
     :offset 0
     :clock  transport/*clock*
-    :proto nil}
+    :proto  nil}
    player
    opts))
 
@@ -370,7 +370,7 @@
     (swap! pplayers update k
            (fn [player]
              (merge (popts player opts)
-                    {:pseq    pattern})))))
+                    {:pseq pattern})))))
 
 (defn- align-pseq [beat quant pseq]
   (let [beat (dec beat) ;; 0-based, so we can do modulo

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -317,10 +317,9 @@
 (defn- player-schedule-next [{:keys [clock playing pseq beat proto] :as player}]
   (if (or (not playing) (not player))
     player
-    (let [e         (merge {:clock transport/*clock*}
+    (let [e         (merge {:clock clock}
                            (pattern/pfirst pseq)
                            proto)
-          dur       (eget e :dur)
           next-seq  (pattern/pnext pseq)
           dur       (eget e :dur)
           next-e    (pattern/pfirst next-seq)
@@ -409,7 +408,6 @@
    (= [13/2 (drop 3 ps)] (align-pseq 6 4 ps))])
 
 (defn- player-resume [{:keys [clock beat quant align offset]
-                       :or {clock transport/*clock*}
                        old-pseq :pseq
                        :as player}
                       pseq
@@ -417,6 +415,7 @@
   ;; TODO: this is not yet taking :offset into account
   (let [align (:align opts (:align player :wait))
         quant (:quant opts (:quant player 4))
+        clock (:clock opts (:clock player transport/*clock*))
         proto (:proto opts (:proto player))
         playing (some :playing (vals @pplayers))
         beat (if playing
@@ -485,6 +484,7 @@
 
   - `:proto` event prototype, a map with common attributes that gets merged into
     the event maps
+  - `:clock` the clock to use for scheduling events
   - `:offset` wait this many beats before starting the pattern
   - `:quant` start the pattern at a beat number that is a multiple of `:quant`
   "

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -353,10 +353,6 @@
   [k pattern & {:as opts}]
   (let [pattern (cond-> pattern (map? pattern) pattern/pbind)]
     (swap! pplayers update k
-
-(defn- align-pseq [beat quant pseq]
-  (let [beat (dec beat) ;; 0-based, so we can do modulo
-        next-beat (mod beat quant)
            (fn [player]
              (let [align (:align opts (:align player :wait))
                    quant (:quant opts (:quant player 4))
@@ -370,6 +366,10 @@
                        :quant   quant
                        :offset  offset
                        :proto   proto}))))))
+
+(defn- align-pseq [beat quant pseq]
+  (let [beat (dec beat) ;; 0-based, so we can do modulo
+        next-beat (mod beat quant)
         [diff pseq] (loop [nb next-beat
                            ps pseq]
                       ;; (prn nb ps)

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -1,0 +1,33 @@
+(ns overtone.studio.event-test
+  (:require
+   [clojure.test :refer [deftest testing is are]]
+   [overtone.music.rhythm :refer [metronome]]
+   [overtone.studio.event :as event]
+   [overtone.studio.transport :as transport]))
+
+(deftest pplay
+  (testing "pplay parameters initialized with defaults"
+    (event/pplay ::player1
+                 [{:type :ctl
+                   :dur 4}])
+    (is (= {:clock  transport/*clock*
+            ;; :offset 0
+            :proto  nil
+            :quant  4}
+           (-> @event/pplayers ::player1
+               (select-keys [:clock :offset :proto :quant])))))
+  (testing "pplay parameters accepted as kv params"
+    (let [clock (metronome 100)]
+      (event/pplay ::player2
+                   [{:type :ctl
+                     :dur 4}]
+                   :clock clock
+                   :offset 2
+                   :proto {:mode :minor}
+                   :quant 8)
+      (is (= {:clock  clock
+              ;; :offset 2
+              :quant  8
+              :proto  {:mode :minor}}
+             (-> @event/pplayers ::player2
+                 (select-keys [:clock :offset :proto :quant])))))))

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -3,31 +3,70 @@
    [clojure.test :refer [deftest testing is are]]
    [overtone.music.rhythm :refer [metronome]]
    [overtone.studio.event :as event]
-   [overtone.studio.transport :as transport]))
+   [overtone.studio.transport :as transport]
+   [overtone.sc.node]))
+
+(def player-init-keys [:align :clock :offset :proto :quant])
+(def player-run-keys [:beat :playing])
+
+(def dummy-instrument (reify overtone.sc.node/IControllableNode
+                        (node-control [_this _params])))
+(def dummy-pattern [{:type :ctl
+                     :instrument dummy-instrument
+                     :dur 4}])
 
 (deftest pplay
   (testing "pplay parameters initialized with defaults"
     (event/pplay ::player1
-                 [{:type :ctl
-                   :dur 4}])
+                 dummy-pattern)
     (is (= {:clock  transport/*clock*
-            ;; :offset 0
+            :offset 0
+            :align  :wait
             :proto  nil
             :quant  4}
            (-> @event/pplayers ::player1
-               (select-keys [:clock :offset :proto :quant])))))
+               (select-keys player-init-keys)))))
   (testing "pplay parameters accepted as kv params"
     (let [clock (metronome 100)]
       (event/pplay ::player2
-                   [{:type :ctl
-                     :dur 4}]
-                   :clock clock
+                   dummy-pattern
+                   :clock  clock
                    :offset 2
-                   :proto {:mode :minor}
-                   :quant 8)
+                   :align  :quant
+                   :proto  {:mode :minor}
+                   :quant  8)
       (is (= {:clock  clock
-              ;; :offset 2
+              :offset 2
+              :quant  8
+              :align  :quant
+              :proto  {:mode :minor}}
+             (-> @event/pplayers ::player2
+                 (select-keys player-init-keys)))))))
+
+(deftest padd
+  (testing "padd parameters initialized with defaults"
+    (event/padd ::player1
+                dummy-pattern)
+    (is (= {:clock  transport/*clock*
+            :offset 0
+            :align  :wait
+            :proto  nil
+            :quant  4}
+           (-> @event/pplayers ::player1
+               (select-keys player-init-keys)))))
+  (testing "padd parameters accepted as kv params"
+    (let [clock (metronome 100)]
+      (event/padd ::player2
+                  dummy-pattern
+                  :clock  clock
+                  :offset 2
+                  :align  :quant
+                  :proto  {:mode :minor}
+                  :quant  8)
+      (is (= {:clock  clock
+              :offset 2
+              :align  :quant
               :quant  8
               :proto  {:mode :minor}}
              (-> @event/pplayers ::player2
-                 (select-keys [:clock :offset :proto :quant])))))))
+                 (select-keys player-init-keys)))))))


### PR DESCRIPTION
- [x] Store `:proto` when passed to `pplay`.
- [x] Accept `:clock` passed to `pplay`.
- [x] Test that the values are captured or defaulted correctly.
- [x] Updates to `padd` (See first question)

Questions:
1. ~~Should `padd` also accept `:proto`? And shouldn't the  parameters to `padd` follow the same rules as `presume`, namely, to take their value from `opts`, or from the current player, and lastly a fixed default?~~ `padd` now uses the same option handling.
1. For the test, this PR removed the `^:private` annotation from `pplayers` atom. Should we leave that unchanged and add a `pget` accessor instead?