### PR TITLE
Fix main program execution error for the melody example 

### DIFF
--- a/src/overtone/examples/getting_started/melody.clj
+++ b/src/overtone/examples/getting_started/melody.clj
@@ -44,10 +44,12 @@
   (play (after 8 metro) notes)
   (play (after 16 metro) notes))
 
-;(play (metronome 120) melody)
-;(play-round (metronome 120) melody)
+(comment
+  (play (metronome 120) melody)
+  (play-round (metronome 120) melody)
+  )
 
-(defn -main [& args]
+(defn -main [& _args]
   (let [metro (metronome 120)]
 
     ;; play the melody
@@ -55,4 +57,9 @@
     (play-round (after 16 metro) melody)
 
     ;; wait for the melody to finish
-    (Thread/sleep (- (metro 48) (now)))))
+    (let [sleep-duration (-> (metro 48)
+                             (- (now))
+                             (long))]
+      (println "sleeping for " sleep-duration " milliseconds to allow melody to play")
+      (Thread/sleep sleep-duration)
+      (System/exit 0))))


### PR DESCRIPTION
Main program was giving the following error: 

  Execution error (IllegalArgumentException) at overtone.examples.getting-started.melody/-main (melody.clj:58).
  No matching method sleep found taking 1 args

This change fixes the call to sleep and also adds an explicit call to System/exit to ensure that the program actually exits after the sleep.