### PR TITLE
Fix pattern quantization, with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Added
+- [588](https://github.com/overtone/overtone/pull/588): Support `offset` quantization parameter in `pplay`, `padd`, and `presume`. Added quantization tests.
 
 ## Fixed
 - [573](https://github.com/overtone/overtone/pull/573): reduce likelihood of choosing a used random port for `scsynth`

--- a/deps.edn
+++ b/deps.edn
@@ -15,8 +15,7 @@
  :aliases
  {:test
   {:extra-paths ["test"]
-   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
-                com.gfredericks/test.chuck {:mvn/version "0.2.14"}}}
+   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}}
   :test-runner
   {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
    :main-opts ["-m" "kaocha.runner"]}

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,9 @@
 
  :aliases
  {:test
-  {:extra-paths ["test"]}
+  {:extra-paths ["test"]
+   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
+                com.gfredericks/test.chuck {:mvn/version "0.2.14"}}}
   :test-runner
   {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
    :main-opts ["-m" "kaocha.runner"]}

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -19,7 +19,7 @@
   ^:private
   player-pool (at-at/mk-pool))
 
-(defonce ^:private pplayers (atom {}))
+(defonce pplayers (atom {}))
 
 (def ^:private event-defaults
   {:note

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -367,11 +367,12 @@
   (let [next-beat (- (mod (- beat quant-base) quant) offset)
         [diff pseq] (loop [nb next-beat
                            ps pseq]
-                      ;; (prn nb ps)
-                      (if (< 0 nb)
+                      (cond
+                        (>= 0 nb) [nb ps]
+                        (empty? ps) [0 ps]
+                        :else
                         (let [dur (eget (pattern/pfirst ps) :dur)]
-                          (recur (- nb dur) (pattern/pnext ps)))
-                        [nb ps]))]
+                          (recur (- nb dur) (pattern/pnext ps)))))]
     ;; diff is always 0 or negative, so returned beat is beat or later
     [(- beat diff)
      pseq]))

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -413,7 +413,6 @@
                        :as player}
                       pseq
                       opts]
-  ;; TODO: this is not yet taking :offset into account
   (let [align (:align opts (:align player :wait))
         quant (:quant opts (:quant player 4))
         offset (:offset opts (:offset player 0))

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -363,8 +363,8 @@
 
    When not on the current quantized beat, removes events from the pseq
    as though they had played starting at the last quantized beat."
-  [beat quant quant-base pseq]
-  (let [next-beat (mod (- beat quant-base) quant)
+  [beat quant-base quant offset pseq]
+  (let [next-beat (- (mod (- beat quant-base) quant) offset)
         [diff pseq] (loop [nb next-beat
                            ps pseq]
                       ;; (prn nb ps)
@@ -372,6 +372,7 @@
                         (let [dur (eget (pattern/pfirst ps) :dur)]
                           (recur (- nb dur) (pattern/pnext ps)))
                         [nb ps]))]
+    ;; diff is always 0 or negative, so returned beat is beat or later
     [(- beat diff)
      pseq]))
 
@@ -441,7 +442,7 @@
                         ;; Honor the quant value, but switch immediately,
                         ;; possibly skipping over notes
                         :quant
-                        (align-pseq beat quant quant-base pseq)
+                        (align-pseq beat quant-base quant offset pseq)
                         :wait
                         (if-not (:playing player)
                           ;; we aren't playing yet, so start the sequence at the

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -444,13 +444,13 @@
                         :quant
                         (align-pseq beat quant-base quant offset pseq)
                         :wait
-                        (if-not (:playing player)
-                          ;; we aren't playing yet, so start the sequence at the
-                          ;; next available sync point (e.g. bar)
-                          [(quantize-ceil beat quant quant-base) pseq]
-                          ;; We are already playing, let the old pattern play
-                          ;; out until we are ready to switch
-                          (let [switch (quantize-ceil beat quant quant-base)]
+                        (let [switch (+ (quantize-ceil beat quant quant-base) offset)]
+                          (if-not (:playing player)
+                            ;; we aren't playing yet, so start the sequence at the
+                            ;; next available sync point (e.g. bar)
+                            [switch pseq]
+                            ;; We are already playing, let the old pattern play
+                            ;; out until we are ready to switch
                             [beat (concat (take-pseq (- switch beat) old-pseq)
                                           pseq)]))
                         ;; Base case, just start at the next beat

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -310,7 +310,7 @@
 
 (declare schedule-next)
 
-(defn- schedule-next-job [clock beat k]
+(defn schedule-next-job [clock beat k]
   (time/with-pool player-pool
     (time/apply-by (clock (dec beat)) schedule-next [k])))
 

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -377,7 +377,10 @@
     [(- beat diff)
      pseq]))
 
-(defn take-pseq [len pseq]
+(defn take-pseq
+  "Return a sequence of exactly `len` beats from the beginning of `pseq`,
+   padding with a rest or shortening the last event as necessary."
+  [len pseq]
   (loop [pseq pseq
          rem len
          res []]

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -393,20 +393,6 @@
                (- rem dur)
                (conj res e))))))
 
-(comment
-  (def ps
-    (overtone.studio.pattern/pbind {:note [:a :b :c :d :e]
-                                    :dur [1 1/2 1 1/16 1/32 1/8]}))
-
-  [(= [0 ps] (align-pseq 0 4 ps))
-   (= [1 (next ps)] (align-pseq 1/2 4 ps))
-   (= [3/2 (next (next ps))] (align-pseq 5/4 4 ps))
-   (= [4 ps] (align-pseq 4 4 ps))
-   (= [1 (next ps)] (align-pseq 1 2 ps))
-   (= [5 (next ps)] (align-pseq 5 4 ps))
-   (= [5/2 (drop 3 ps)] (align-pseq 2 4 ps))
-   (= [13/2 (drop 3 ps)] (align-pseq 6 4 ps))])
-
 (defn- player-resume [{:keys [clock beat quant align offset]
                        :or {clock transport/*clock*}
                        old-pseq :pseq

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -377,7 +377,7 @@
     [(- beat diff)
      pseq]))
 
-(defn- take-pseq [len pseq]
+(defn take-pseq [len pseq]
   (loop [pseq pseq
          rem len
          res []]

--- a/src/overtone/studio/event.clj
+++ b/src/overtone/studio/event.clj
@@ -288,7 +288,7 @@
 
 (defn- quantize-ceil
   "Quantize a beat to a period, rounding up."
-  [beat quant quant-base]
+  [beat quant-base quant]
   (let [m (mod (- beat quant-base) quant)]
     (if (= 0 m)
       beat
@@ -296,7 +296,7 @@
 
 (defn- quantize-floor
   "Quantize a beat to a period, rounding down."
-  [beat quant quant-base]
+  [beat quant-base quant]
   (let [m (mod (- beat quant-base) quant)]
     (if (= 0 m)
       beat
@@ -444,7 +444,7 @@
                         :quant
                         (align-pseq beat quant-base quant offset pseq)
                         :wait
-                        (let [switch (+ (quantize-ceil beat quant quant-base) offset)]
+                        (let [switch (+ (quantize-ceil beat quant-base quant) offset)]
                           (if-not (:playing player)
                             ;; we aren't playing yet, so start the sequence at the
                             ;; next available sync point (e.g. bar)

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -97,7 +97,9 @@
                          remaining-beats (- (pseq-dur pseq-b) beats-to-remove)]
                      (is (= (max remaining-beats 0)
                             (pseq-dur next-seq-b)))
-                     (is (= b-start next-beat-b)))
+                     (is (= b-start next-beat-b))
+                     (is (= (event/drop-pseq beats-to-remove pseq-b)
+                            next-seq-b)))
 
                    :none
                    ;; Start immediately with no quantization

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -16,7 +16,7 @@
                      :instrument dummy-instrument
                      :dur 4}])
 
-(defspec quantization 10
+(defspec quantization 10000
   (let [align      (gen/elements [:wait :quant :none])
         quant      (gen/choose 1 10)
         offset     (gen/choose 0 10)

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -90,14 +90,13 @@
                        (is (= pseq-b next-seq-b))))
 
                    :quant
-                   ;; Start sequence now or prior quantization beat, trimming events
-                   ;; as necessary such that the first new event is in the future.
+                   ;; Start sequence now or at prior quantization beat, trimming events
+                   ;; as necessary such that the first new event from pseq is in the future.
+                   ;; next-seq-b may have a `:rest` inserted at the start to align first event.
                    (let [beats-to-remove (- (mod start-after quant) offset)
                          remaining-beats (- (pseq-dur pseq-b) beats-to-remove)]
-                     (if (< remaining-beats 0)
-                       (is (zero? (pseq-dur next-seq-b)))
-                       (is (= remaining-beats
-                              (pseq-dur next-seq-b))))
+                     (is (= (max remaining-beats 0)
+                            (pseq-dur next-seq-b)))
                      (is (= b-start next-beat-b)))
 
                    :none

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer [deftest testing is are]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
-   [com.gfredericks.test.chuck.clojure-test :refer [checking for-all] :as prop]
+   [clojure.test.check.properties :refer [for-all]]
    [overtone.music.rhythm :refer [metronome metro-start]]
    [overtone.studio.event :as event]
    [overtone.studio.pattern :as pattern]

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -1,0 +1,70 @@
+(ns overtone.studio.event-test
+  (:require
+   [clojure.test :refer [deftest testing is are]]
+   [clojure.test.check.clojure-test :refer [defspec]]
+   [clojure.test.check.generators :as gen]
+   [com.gfredericks.test.chuck.clojure-test :refer [checking for-all] :as prop]
+   [overtone.music.rhythm :refer [metronome metro-start]]
+   [overtone.studio.event :as event]
+   [overtone.studio.transport :as transport]
+   [overtone.sc.node]))
+
+(def dummy-pattern [{:type :ctl
+                     :instrument dummy-instrument
+                     :dur 4}])
+
+(defspec quantization 10
+  (let [align      (gen/elements [:wait #_:quant #_:none])
+        quant      (gen/choose 1 10)
+        offset     (gen/choose 0 10)
+        pattern    (gen/return dummy-pattern)
+        clock      (gen/return (metronome 1))
+
+        params (gen/hash-map
+                :align align
+                :quant quant
+                :offset offset
+                :clock clock)
+
+        pseq-a dummy-pattern]
+    (for-all [start-beat (gen/choose 1 100)
+              start-after (gen/choose 0 10)
+              params     params
+              pseq-b     pattern]
+             (with-redefs [event/schedule-next-job (fn [_clock _beat _k])]
+               ;; Clear players
+               (event/pclear)
+
+               ;; metro-start rounds up to next beat, so we decrement to
+               ;; ensure (clock) yields start-beat
+               (metro-start (:clock params) (dec start-beat))
+               (event/pplay ::a pseq-a params)
+
+               (when (< 0 start-after)
+                 (metro-start (:clock params) (dec (+ start-beat start-after))))
+               (event/pplay ::b pseq-b params)
+
+               (let [{:keys [align quant offset]} params
+                     {next-beat-a :beat} (::a @event/pplayers)
+                     {next-beat-b :beat
+                      next-seq-b :pseq}  (::b @event/pplayers)]
+                 (is (= start-beat next-beat-a))
+                 (case align
+                   :wait  (let [b-start (+ start-beat start-after)
+                                q-mod   (mod (- quant (mod start-after quant)) quant)
+                                quantized-b-start (+ b-start q-mod #_offset)]
+                            #_(future (prn [:start-beat start-beat
+                                            :start-after start-after
+                                            :b-start b-start
+                                            :quant quant
+                                            :offset offset
+                                            :quantized quantized-b-start
+                                            :next-beat-b next-beat-b
+                                            :pseq-b-start-fix pseq-b-start-fix
+                                            :fixed-quant (+ quantized-b-start
+                                                            (if (zero? start-after)
+                                                              pseq-b-start-fix
+                                                              0))]))
+                            (is (= quantized-b-start next-beat-b)))
+                   :quant (is (= 1 1))
+                   :none  (is (= 1 1))))))))

--- a/test/overtone/studio/event_test.clj
+++ b/test/overtone/studio/event_test.clj
@@ -9,6 +9,8 @@
    [overtone.studio.transport :as transport]
    [overtone.sc.node]))
 
+(def dummy-instrument (reify overtone.sc.node/IControllableNode
+                        (node-control [_this _params])))
 (def dummy-pattern [{:type :ctl
                      :instrument dummy-instrument
                      :dur 4}])


### PR DESCRIPTION
In order to support both quantization and the ability to start a pattern playing immediately when no other pattern is playing, quantization needs to be relative to the start of the first pattern, _not_ relative to clock/metronome `1` beat.

Therefore, this PR introduces a `:quant-base` key which stores the beat at which a player began playing. When resuming a new player, we now look at all the currently playing sequences and quantize off the one that started earliest.

The change simplifies `quantize-ceil` and `quantize-floor`, because rather than quantizing against an implicit beat `1` start, we use `quant-base`.

- [x] Use `quant-base` to support synchronizing with existing sequences started at arbitrary clock beats.
- [x] Add `offset` support.

Question:
- Tests confirm that `offset` works when zero or greater. @plexus, is it intended that it should ever be negative?