### PR TITLE
Fix inst stereo mixer

### DIFF
--- a/src/overtone/studio/inst.clj
+++ b/src/overtone/studio/inst.clj
@@ -56,12 +56,14 @@
        out-bus 0
        volume  DEFAULT-VOLUME
        pan     DEFAULT-PAN]
-      (let [snd  (in in-bus 2)
-            snd (select (check-bad-values snd 0 0)
-                        [snd (dc 0) (dc 0) snd])
-            snd (limiter snd 0.99 0.001)
-            sndl (select 0 snd)
-            sndr (select 1 snd)]
+      (let [sndl (in in-bus 1)
+            sndl (select (check-bad-values sndl 0 0)
+                         [sndl (dc 0) (dc 0) sndl])
+            sndl (limiter sndl 0.99 0.001)
+            sndr (in (+ in-bus 1) 1)
+            sndr (select (check-bad-values sndr 0 0)
+                         [sndr (dc 0) (dc 0) sndr])
+            sndr (limiter sndr 0.99 0.001)]
         (out out-bus (balance2 sndl sndr pan volume))))))
 
 (defn inst-mixer

--- a/src/overtone/studio/inst.clj
+++ b/src/overtone/studio/inst.clj
@@ -56,13 +56,14 @@
        out-bus 0
        volume  DEFAULT-VOLUME
        pan     DEFAULT-PAN]
-      (let [sndl (in in-bus 1)
+      (let [zero (dc 0)
+            sndl (in in-bus 1)
             sndl (select (check-bad-values sndl 0 0)
-                         [sndl (dc 0) (dc 0) sndl])
+                         [sndl zero zero sndl])
             sndl (limiter sndl 0.99 0.001)
             sndr (in (+ in-bus 1) 1)
             sndr (select (check-bad-values sndr 0 0)
-                         [sndr (dc 0) (dc 0) sndr])
+                         [sndr zero zero sndr])
             sndr (limiter sndr 0.99 0.001)]
         (out out-bus (balance2 sndl sndr pan volume))))))
 


### PR DESCRIPTION
Inspired by @jave's [question](https://clojurians.slack.com/archives/C053Q1QSG/p1738800087725859), I started exploring the issue he noticed, that he was not hearing stereo imaging from stereo instruments. It turns out that the stereo mixer as written does not work.

```clojure
;; Current implementation
(defsynth stereo-inst-mixer
      [in-bus  10
       out-bus 0
       volume  DEFAULT-VOLUME
       pan     DEFAULT-PAN]
      (let [snd  (in in-bus 2)
            snd  (select (check-bad-values snd 0 0)
                        [snd (dc 0) (dc 0) snd])
            snd  (limiter snd 0.99 0.001)
            sndl (select 0 snd)
            sndr (select 1 snd)]
        (out out-bus (balance2 sndl sndr pan volume))))))
```

`snd` is two channels, but the channel expansion of `select` results in a 6 channel array. `check-bad-values` outputs an index that requires a length 4 array. The result was that the left channel was used for both channels.

<img width="871" alt="Original Mixer Ugen Graph" src="https://github.com/user-attachments/assets/d9f6331f-4393-4207-b180-f7a34df48b2a" />

The rewrite in this PR avoids the error by handling left and right channels separately.

```clojure
;; Rewrite
    (defsynth stereo-inst-mixer
      [in-bus  10
       out-bus 0
       volume  DEFAULT-VOLUME
       pan     DEFAULT-PAN]
      (let [zero (dc 0)
            sndl (in in-bus 1)
            sndl (select (check-bad-values sndl 0 0)
                         [sndl zero zero sndl])
            sndl (limiter sndl 0.99 0.001)
            sndr (in (+ in-bus 1) 1)
            sndr (select (check-bad-values sndr 0 0)
                         [sndr zero zero sndr])
            sndr (limiter sndr 0.99 0.001)]
        (out out-bus (balance2 sndl sndr pan volume))))))
```

<img width="729" alt="New Mixer Ugen Graph" src="https://github.com/user-attachments/assets/4cd4b68f-7917-4d94-8e0d-6862595f021f" />
