### PR TITLE
fix: change `and` to `*` to ensure triggers work as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [583](https://github.com/overtone/overtone/pull/583): `bass` and `grunge-bass` in `overtone.inst.synth` both now mix 3 audio channels (center freq and detuned high and low) to a single channel.
 - [592](https://github.com/overtone/overtone/pull/592): The output mixer for stereo instruments now includes both channels in the balance.
 - [551](https://github.com/overtone/overtone/issues/551): Fix MIDI number calculation beyond octave boundaries
+- [593](https://github.com/overtone/overtone/pull/593): Fix internal sequencer example to use `*` instead of `and`
 
 ## Breaking Changes
 - [582](https://github.com/overtone/overtone/pull/582) adds the potemkin lib, which makes Inst accept up to 21 arguments if you use `apply`, also the Inst class has two more params (`m` and `mta`) for its constructor

--- a/src/overtone/examples/timing/internal_sequencer.clj
+++ b/src/overtone/examples/timing/internal_sequencer.clj
@@ -66,7 +66,7 @@
   [buf 0 rate 1 out-bus 0 beat-num 0 sequencer 0 amp 1]
   (let [cnt      (in:kr beat-cnt-bus)
         beat-trg (in:kr beat-trg-bus)
-        bar-trg  (and (buf-rd:kr 1 sequencer cnt)
+        bar-trg  (* (buf-rd:kr 1 sequencer cnt)
                       (= beat-num (mod cnt 8))
                       beat-trg)
         vol      (set-reset-ff bar-trg)]


### PR DESCRIPTION
This makes a slight change to the `timing/internal-sequence` example to use `*` instead of `and` for combining triggers with note values. Without this fix, every synth triggers on every beat, regardless of beat number or the note stored in the corresponding buffer (this is also very loud b/c all synths for each sample trigger for each beat). I'm guessing in the past `and` worked as expected, but now returns a value that always activates the trigger.

Please answer the following question and leave the below in as part of your PR.

- [x] I have updated the [CHANGELOG.md](https://github.com/overtone/overtone/blob/master/CHANGELOG.md) file with a description of the addressed issue.



