### PR TITLE
Fix calling a synth/inst with more than 22 parameters

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,8 @@
   babashka/process {:mvn/version "0.5.22"}
 
   ;; For custom data structures.
-  potemkin/potemkin {:mvn/version "0.4.7"}}
+  potemkin/potemkin {:git/url "https://github.com/plexus/potemkin"
+                     :git/sha "b6222866c0161f64bd556dcd9af3d5cdbe07bdba"}}
 
  :aliases
  {:test

--- a/src/overtone/helpers/lib.clj
+++ b/src/overtone/helpers/lib.clj
@@ -267,7 +267,10 @@
                           :else
                           `(~'invoke [this# ~@args]
                             (~invoke-fn this# ~@args)))))
-                    (range 22)))
+                    (range 22))
+
+             (~'applyTo [this# args#]
+              (apply ~invoke-fn this# args#)))
 
            (defn ~(symbol (str "->" rec-name)) [~@fields]
              (new ~rec-name ~@fields {} nil))


### PR DESCRIPTION
**DO NOT MERGE**

This doesn't actually work, since potemkin contains java sources that need to be compiled. Upstream issue is here: https://github.com/clj-commons/potemkin/pull/82 , if we can get that released we can bump potemkin and include this fix.


